### PR TITLE
feat: InformationContainer 1차

### DIFF
--- a/src/components/atom/openConfirmedBadge/index.tsx
+++ b/src/components/atom/openConfirmedBadge/index.tsx
@@ -1,0 +1,34 @@
+interface OpenConfirmedBadgeProps {
+  participantCount: number;
+}
+
+export const OpenConfirmedBadge = ({
+  participantCount,
+}: OpenConfirmedBadgeProps) => {
+  return participantCount >= 5 ? (
+    <div>
+      <div className="flex h-6 w-fit items-center justify-center">
+        <div className="bg-primary-500 flex size-4.5 items-center justify-center rounded-full">
+          <svg
+            width="10"
+            height="7"
+            viewBox="0 0 10 7"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M1.5 2.82453L4.00872 5.33325L8.34198 1"
+              stroke="white"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </div>
+        <span className="text-primary-500 pl-1.5">개설확정</span>
+      </div>
+    </div>
+  ) : (
+    <></>
+  );
+};

--- a/src/components/atom/progressBar/index.tsx
+++ b/src/components/atom/progressBar/index.tsx
@@ -20,7 +20,7 @@ export const ProgressBar = ({
 
   return (
     <div
-      className={`h-1 w-full max-w-60 rounded-md ${isColored ? "bg-orange-50" : "bg-gray-200"} `}
+      className={`h-1 w-full rounded-md ${isColored ? "bg-orange-50" : "bg-gray-200"} `}
     >
       <motion.div
         className={clsx("h-full rounded-md", {

--- a/src/components/molecules/gatheringInformation/avatarList.tsx
+++ b/src/components/molecules/gatheringInformation/avatarList.tsx
@@ -1,0 +1,44 @@
+import { Avatar } from "@/components/atom/avatar";
+import { useEffect, useState } from "react";
+
+// User 타입은 추후 api 응답 결과에 맞게 변경 예정입니다.
+export type User = {
+  id: number;
+  name: string;
+  image?: string;
+};
+
+interface AvartarListProps {
+  UserList: User[];
+}
+
+export const AvartarList = ({ UserList }: AvartarListProps) => {
+  const [displayUserList, setDisaplayUserList] = useState(UserList); // 프로필 사진이 보여지는 사용자 리스트
+  const [overNumber, setOverNumber] = useState(0); // 5명 이상일 경우, 숫자로 표기되는 인원 수
+  useEffect(() => {
+    if (UserList.length > 5) {
+      setDisaplayUserList(UserList.slice(0, 4));
+      setOverNumber(UserList.length - 4);
+    }
+  }, [UserList]);
+
+  return (
+    <div className="flex -space-x-2.5">
+      {displayUserList.map((user) => (
+        <Avatar
+          key={user.id}
+          username={user.name}
+          className="h-[30px] w-[30px]"
+          src={user.image}
+        />
+      ))}
+
+      {/* 5명 이상일 경우, 숫자로 표기되는 인원 수  */}
+      {UserList.length > 5 && (
+        <div className="bg-secondary-100 text-secondary-800 flex h-[30px] w-[30px] items-center justify-center rounded-full text-sm font-semibold">
+          +{overNumber}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/molecules/gatheringInformation/index.spec.tsx
+++ b/src/components/molecules/gatheringInformation/index.spec.tsx
@@ -1,0 +1,45 @@
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import { test, describe, expect, vi } from "vitest";
+import { GatheringInformation } from ".";
+import { Gathering } from "@/entity/gathering";
+import { useEffect, useState } from "react";
+// 예시 mock 데이터
+const mockGathering: Gathering = {
+  teamId: 5,
+  id: 123,
+  type: "string",
+  name: "달램핏 오피스 스트레칭",
+  dateTime: "2025-05-21T09:06:50.733Z",
+  registrationEnd: "2025-05-21T09:06:50.733Z",
+  location: "을지로 3가 서울시 중구 청계천로 100",
+  participantCount: 16,
+  capacity: 20,
+  image: "string",
+  createdBy: 0,
+  canceledAt: "2025-05-21T09:06:50.733Z",
+};
+
+test("비동기 API 응답 후 GatheringInformation 컴포넌트가 렌더링 된다", async () => {
+  // 가상의 fetch 함수가 있다고 가정하고 모킹
+  const fetchGathering = vi.fn().mockResolvedValue(mockGathering);
+
+  const AsyncWrapper = () => {
+    const [gathering, setGathering] = useState<Gathering | null>(null);
+
+    useEffect(() => {
+      fetchGathering().then(setGathering);
+    }, []);
+
+    if (!gathering) return <div>Loading...</div>;
+
+    return <GatheringInformation gatheringInfo={gathering} />;
+  };
+
+  render(<AsyncWrapper />);
+
+  // "달램핏 오피스 스트레칭" 텍스트가 뜨는지 확인 (비동기 렌더링 기다리기)
+  await waitFor(() => {
+    expect(screen.getByText("달램핏 오피스 스트레칭")).toBeInTheDocument();
+    expect(screen.getByText(/을지로 3가/)).toBeInTheDocument();
+  });
+});

--- a/src/components/molecules/gatheringInformation/index.tsx
+++ b/src/components/molecules/gatheringInformation/index.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { InfoChip } from "@/components/atom/infoChip";
+import { ParticipantInfo } from "./participantInfo";
+import { LikeButton } from "@/components/atom/likeButton";
+import { useEffect, useState } from "react";
+import { Gathering } from "@/entity/gathering";
+
+interface GatheringInformationProps {
+  gatheringInfo: Gathering;
+}
+
+export const GatheringInformation = ({
+  gatheringInfo,
+}: GatheringInformationProps) => {
+  const [isLiked, setIsLiked] = useState(true);
+
+  useEffect(() => {
+    // 좋아요 액션 처리 (gatheringInfo.id 기반)
+  }, [isLiked]);
+  return (
+    <div className="relative flex h-60 w-full flex-col rounded-3xl border-2 border-gray-200 bg-white px-6 py-6 md:h-[270px]">
+      {/* 찜하기 버튼 */}
+      <div className="absolute top-6 right-6">
+        <LikeButton isLiked={isLiked} setIsLiked={setIsLiked} />
+      </div>
+
+      {/* 상세 정보 */}
+      <div className="relative flex w-fit grow flex-col">
+        <p className="text-lg font-semibold">{gatheringInfo?.name}</p>
+        <p className="text-sm font-medium text-gray-700">
+          {gatheringInfo?.location}
+        </p>
+        <div className="mt-3.5 flex gap-x-2">
+          {/* gatheringInfo.dateTime 처리해서 넘겨주기 */}
+          <InfoChip type="date">1월 7일</InfoChip>
+          <InfoChip type="time">17:30</InfoChip>
+        </div>
+      </div>
+
+      {/* 구분선 */}
+      <hr className="-mx-6 my-4 border-t-2 border-dashed border-gray-200" />
+
+      {/* 참여 인원 정보 */}
+      <ParticipantInfo
+        participantCount={gatheringInfo.participantCount}
+        capacity={gatheringInfo.capacity}
+      />
+    </div>
+  );
+};

--- a/src/components/molecules/gatheringInformation/participantInfo.tsx
+++ b/src/components/molecules/gatheringInformation/participantInfo.tsx
@@ -1,0 +1,69 @@
+// 상세페이지 내 모집 정원, 최소인원, 최대인원 등의 정보를 나타내는 컴포넌트
+import { ProgressBar } from "@/components/atom/progressBar";
+import { AvartarList } from "./avatarList";
+import { OpenConfirmedBadge } from "@/components/atom/openConfirmedBadge";
+
+import { User } from "./avatarList";
+// 예시 데이터 입니다 (추후 삭제 예정)
+export const userListExample: User[] = [
+  {
+    id: 1,
+    name: "Alice",
+  },
+  {
+    id: 2,
+    name: "Bob",
+  },
+  {
+    id: 3,
+    name: "Charlie",
+  },
+  {
+    id: 4,
+    name: "Lee",
+  },
+  {
+    id: 5,
+    name: "Seo",
+  },
+  {
+    id: 6,
+    name: "Eunbin",
+  },
+];
+
+interface ParticipantInfoProps {
+  participantCount: number;
+  capacity: number;
+}
+
+export const ParticipantInfo = ({
+  participantCount,
+  capacity,
+}: ParticipantInfoProps) => {
+  return (
+    <div className="flex w-full flex-col gap-y-2.5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center">
+          {/* 숫자 올라가는 애니메이션 추가해야함 */}
+          <div className="mr-3 text-sm font-semibold">
+            모집정원 {participantCount}명
+          </div>
+          {/* props 수정 필요 */}
+          <AvartarList UserList={userListExample} />
+        </div>
+        {/* 개설확정 뱃지*/}
+        <OpenConfirmedBadge participantCount={participantCount} />
+      </div>
+      <ProgressBar
+        currentCount={participantCount}
+        totalCount={capacity}
+        isAnimated={true}
+      />
+      <div className="flex justify-between text-xs font-medium">
+        <p>최소인원 {5}명</p>
+        <p>최대인원 {capacity}명</p>
+      </div>
+    </div>
+  );
+};

--- a/src/entity/gathering.ts
+++ b/src/entity/gathering.ts
@@ -1,0 +1,15 @@
+// Gathering(모임) 전체 타입
+export interface Gathering {
+  teamId: number;
+  id: number;
+  type: string;
+  name: string;
+  dateTime: string;
+  registrationEnd: string;
+  location: string;
+  participantCount: number;
+  capacity: number;
+  image: string;
+  createdBy: number;
+  canceledAt: string | null;
+}


### PR DESCRIPTION
## 작업 내용
작업 내용이 많아지는 것 같아 1차 pr 먼저 올립니다.
- openConfirmedBadge (신청 인원 5명 이상일 경우 나타나는 개설확정 뱃지)
- progressBar 스타일 수정
- avatarList 
> 현재는 예시 데이터를 임의로 넣어두었습니다. 추후, 타입 재정의 및 예시데이터 삭제 예정입니다.
- gatheringInformation (모임 상세 정보 container)
> - 날짜 및 시간 관련 데이터 처리 유틸함수 생성 후 수정 예정
> - 좋아요 액션 처리 예정
- participantInfo (모임 인원 관련 정보)
- gathering (api 요청 응답으로 오는 '모임' 객체 정의)