### PR TITLE
[refactor] Modal 컴포넌트 구조 및 위치 설정 개선 (#48)

### DIFF
--- a/src/components/atom/modal/index.tsx
+++ b/src/components/atom/modal/index.tsx
@@ -4,86 +4,100 @@ import { CloseIcon } from "@/components/icons/CloseIcon";
 
 // 프롭스 인터페이스
 interface ModalProps {
-  isOpen: boolean;                        // 모달 열림 여부
-  onClose: () => void;                    // 닫기 핸들러 (배경 클릭 or 닫기 버튼 클릭 시)
-  title?: string;                         // 타이틀명
-  showHeader?: boolean;                   // 헤더 영역 표시 여부
-  showCloseButton?: boolean;              // 헤더 닫기 버튼 표시 여부
-  showFooter?: boolean;                   // 푸터 영역 표시 여부
-  footer?: React.ReactNode;               // 푸터 버튼 요소
-  children: React.ReactNode;              // 콘텐츠 영역 (본문)
-  size?: "sm" | "md" | "lg" | "full";     // 모달 너비
-  dimmer?: boolean                        // 배경 디머 표시 여부
+  isOpen: boolean; // 모달 열림 여부
+  onClose: () => void; // 닫기 핸들러 (배경 클릭 or 닫기 버튼 클릭 시)
+  position?: { top: number; left: number }; // 모달 위치 (top, left)
+  title?: string; // 타이틀명
+  showHeader?: boolean; // 헤더 영역 표시 여부
+  showCloseButton?: boolean; // 헤더 닫기 버튼 표시 여부
+  showFooter?: boolean; // 푸터 영역 표시 여부
+  footer?: React.ReactNode; // 푸터 버튼 요소
+  children: React.ReactNode; // 콘텐츠 영역 (본문)
+  size?: "sm" | "md" | "lg" | "full" | string; // 모달 너비
+  dimmer?: boolean; // 배경 디머 표시 여부
 }
 
 // 모달 컴포넌트 정의
 export const Modal = ({
   isOpen,
   onClose,
+  position,
   title = "",
   showHeader = true,
   showCloseButton = true,
   showFooter = true,
   footer = null,
   children,
-  size = "md",
+  size = "sm",
   dimmer = true,
 }: ModalProps) => {
-  // 열리지 않은 상태면 렌더링하지 않음
   if (!isOpen) return null;
 
   // 모달 너비 클래스 설정
-  const sizeClass = {
+  const predefinedSize = {
     sm: "w-[472px]",
     md: "w-[70%]",
     lg: "w-[90%]",
     full: "w-full",
-  }[size];
+  };
+  const sizeClass =
+    typeof size === "string" && !(size in predefinedSize)
+      ? size
+      : predefinedSize[size as keyof typeof predefinedSize] || "w-[70%]";
 
   return (
     <div
       className={clsx(
-        "fixed inset-0 z-50 flex items-center justify-center",
-        dimmer && "bg-black bg-opacity-50"
+        "fixed inset-0 z-50",
+        dimmer && "bg-black/50",
+        dimmer && "flex items-center justify-center",
       )}
-      onClick={onClose} // 배경 클릭 시 모달 닫기
+      onClick={onClose}
     >
       <div
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"
         className={clsx(
-          "rounded-xl bg-white shadow-lg max-h-[90vh] overflow-y-auto",
-          sizeClass
+          "absolute max-h-[90vh] overflow-y-auto rounded-xl bg-white shadow-lg",
+          sizeClass,
         )}
+        style={
+          !dimmer && position
+            ? { top: position.top, left: position.left }
+            : undefined
+        }
         onClick={(e) => e.stopPropagation()} // 내부 클릭 시 이벤트 버블링 방지
       >
-        <div className="p-6 flex flex-col gap-6">
+        <section className="flex flex-col gap-6 p-6">
           {/* 헤더 */}
           {showHeader && (
-            <div className="flex justify-between items-start">
-              {title && (
-                <h2 id="modal-title" className="text-lg font-semibold">
-                  {title}
-                </h2>
-              )}
+            <header className="flex items-start justify-between">
+              <div className="flex-1">
+                {title && (
+                  <h2 id="modal-title" className="text-lg font-semibold">
+                    {title}
+                  </h2>
+                )}
+              </div>
               {showCloseButton && (
                 <button
                   onClick={onClose}
                   aria-label="닫기"
+                  className="cursor-pointer"
                 >
-                  <CloseIcon className="w-4 h-4" />
+                  <CloseIcon className="h-4 w-4" />
                 </button>
               )}
-            </div>
+            </header>
           )}
 
           {/* 콘텐츠 */}
-          <div>{children}</div>
+          <section>{children}</section>
 
           {/* 푸터 */}
-          {showFooter && footer && <div>{footer}</div>}
-        </div>
+          {showFooter && footer && <footer>{footer}</footer>}
+        </section>
       </div>
     </div>
   );


### PR DESCRIPTION
## 작업 내용  
- position prop 추가로 버튼 기준 위치 지정 가능 (top, left)
- dimmer가 없는 경우에도 바깥 클릭 시 닫히도록 수정
- 내부 구조에 시멘틱 태그 (header, footer) 도입
- 커스텀 사이즈 지원 (size="w-[336px]" 등 tailwind 직접 입력)

Closes #48

## 참고  
사용 예시 및 디자인은 노션 "공통 컴포넌트 설계 페이지" 참고