### PR TITLE
[feature] getGatheringList API 함수 구현 (#91)

### DIFF
--- a/src/effect/gatherings/getGatheringList.ts
+++ b/src/effect/gatherings/getGatheringList.ts
@@ -1,0 +1,10 @@
+const BASE_URL = "https://fe-adv-project-together-dallaem.vercel.app";
+const teamId = "slotest";
+
+export const getGatheringList = async () => {
+  const response = await fetch(`${BASE_URL}/${teamId}/gatherings`);
+  if (!response.ok) {
+    throw new Error("모임 목록을 불러오는 데 실패했습니다");
+  }
+  return await response.json();
+};


### PR DESCRIPTION
## 설명
- 메인 페이지에서 사용할 모임 목록 조회 API 요청 함수(getGatheringList)를 작성했습니다.

## 작업 내용
- API 요청 함수 작성
- 실패 시 예외 처리
- 테스트용 teamId(slotest) 적용

## 기타
- Swagger 문서 기준 /{teamId}/gatherings API 사용
- 상세한 사항은 추후 보완할 예정