### PR TITLE
[fix] GatheringCard 클릭 문제 및 코드 정리 (#108)

### DIFF
--- a/src/app/GatheringListPage.tsx
+++ b/src/app/GatheringListPage.tsx
@@ -5,6 +5,7 @@
 // 초기 데이터는 SSR에서 전달받아 사용합니다.
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useInView } from "react-intersection-observer";
 import { getGatheringList } from "@/effect/gatherings/getGatheringList";
 import { GatheringCard } from "@/components/molecules/gatheringCard";
@@ -63,8 +64,11 @@ export function GatheringListPage({
   const [gatherings, setGatherings] = useState(initialGatherings);
   const [skip, setSkip] = useState(10); // 이미 10개 가져왔으니 10부터 시작
   const { ref, inView } = useInView({ threshold: 0.5 });
-
   const chips = subTabs[selectedTopTab.value];
+  const router = useRouter();
+  const goToGatheringDetail = (id: number) => {
+    router.push(`/detail/${id}`);
+  };
 
   // 탭 변경 시 하위 카테고리 초기화
   useEffect(() => {
@@ -79,7 +83,7 @@ export function GatheringListPage({
         setSkip((prev) => prev + 10);
       });
     }
-  }, [inView]);
+  }, [inView, skip]);
 
   return (
     <main className="flex flex-col bg-gray-100">
@@ -138,9 +142,8 @@ export function GatheringListPage({
             <GatheringCard
               key={gathering.id}
               gathering={gathering}
-              isLiked={false}
               isDimmed={false}
-              onClick={() => console.log("카드 클릭")}
+              onClick={() => goToGatheringDetail(gathering.id)}
             />
           ))}
         </div>

--- a/src/components/atom/likeButton/index.tsx
+++ b/src/components/atom/likeButton/index.tsx
@@ -13,7 +13,8 @@ export const LikeButton = ({ gatheringId }: LikeButtonProps) => {
   // 첫 렌더링시에 isLiked가 true이면 애니메이션 동작하지 않도록 버튼 상호작용 체크
   const [hasInteracted, setHasInteracted] = useState(false);
 
-  const handleHeartClick = () => {
+  const handleHeartClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation(); // 카드 클릭 이벤트 막기
     toggleLike(gatheringId);
     setIsLiked((prev: boolean) => !prev);
     // 사용자가 최초로 버튼을 클릭한 이후만 true

--- a/src/components/molecules/gatheringCard/index.tsx
+++ b/src/components/molecules/gatheringCard/index.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
 import clsx from "clsx";
 import dayjs from "dayjs";
 import { Gathering } from "@/entity/gathering";
@@ -15,34 +13,20 @@ import { ByeIcon } from "@/components/icons/ByeIcon";
 
 export interface GatheringCardProps {
   gathering: Gathering;
-  isLiked?: boolean;
   isDimmed?: boolean;
+  onClick?: () => void;
 }
 
 export const GatheringCard = ({
   gathering,
-  isLiked: likedProp = false,
   isDimmed = false,
+  onClick,
 }: GatheringCardProps) => {
-  const [isLiked, setIsLiked] = useState(likedProp);
   const isFull = gathering.participantCount >= gathering.capacity;
-  const router = useRouter();
-  const goToGatheringDetail = () => {
-    router.push(`/detail/${gathering.id}`); // 모임 상세 페이지로 이동
-  };
-
-  useEffect(() => {
-    const stored = localStorage.getItem(`liked-${gathering.id}`);
-    if (stored === "true") setIsLiked(true);
-  }, [gathering.id]);
-
-  useEffect(() => {
-    localStorage.setItem(`liked-${gathering.id}`, isLiked.toString());
-  }, [isLiked, gathering.id]);
 
   return (
     <article
-      onClick={goToGatheringDetail}
+      onClick={onClick}
       className={clsx(
         "border-secondary-100 relative flex cursor-pointer flex-row overflow-hidden rounded-3xl border-2 bg-white transition",
         {


### PR DESCRIPTION
## 작업 내용
- GatheringCard 컴포넌트에 onClick prop 타입 선언 추가
- GatheringListPage에서 카드 클릭 시 상세페이지 이동 핸들러 전달
- LikeButton 내부 클릭 시 이벤트 전파 방지 (stopPropagation 적용)
- GatheringCard 내부 불필요 goToGatheringDetail 함수 제거

Closes #108 