### PR TITLE
[refactor] 상세페이지 폴더 구조 변경에 따른 라우팅 수정 (#115)

### DIFF
--- a/src/app/GatheringListPage.tsx
+++ b/src/app/GatheringListPage.tsx
@@ -78,7 +78,7 @@ export function GatheringListPage({
   const chips = subTabs[selectedTopTab.value];
 
   const goToGatheringDetail = (id: number) => {
-    router.push(`/detail/${id}`);
+    router.push(`/gathering/${id}`);
   };
 
   const getFormattedDate = (date: Date | null) => {


### PR DESCRIPTION
## 작업 내용
- 기존 `/detail/:id` → 변경된 `/(detail)/gathering/:id` 폴더 구조 반영
- `router.push` 경로 수정

Closes #115