### PR TITLE
[refactor] 모임 찾기 페이지 개선 (#119)

### DIFF
--- a/src/app/GatheringListPage.tsx
+++ b/src/app/GatheringListPage.tsx
@@ -100,12 +100,6 @@ export function GatheringListPage({
   useEffect(() => {
     const formattedDate = getFormattedDate(filters.date);
 
-    console.log(
-      "🚀 [API 요청] type:",
-      selectedChip?.value ?? selectedTopTab.value,
-    );
-    console.log("🚀 [API 요청] filters:", filters);
-
     getGatheringList(0, 10, {
       region: filters.region !== "all" ? filters.region : undefined,
       date: formattedDate,
@@ -122,14 +116,6 @@ export function GatheringListPage({
   useEffect(() => {
     if (inView && hasMore) {
       const formattedDate = getFormattedDate(filters.date);
-
-      console.log(
-        "🌍 [무한스크롤 추가 호출] skip:",
-        skip,
-        "type:",
-        selectedChip?.value ?? selectedTopTab.value,
-      );
-
       getGatheringList(skip, 10, {
         region: filters.region !== "all" ? filters.region : undefined,
         date: formattedDate,
@@ -153,7 +139,7 @@ export function GatheringListPage({
 
       <section
         style={{ minHeight: "calc(100vh - 60px)" }}
-        className="bg-secondary-50 mx-auto w-full max-w-[1200px] px-[100px] py-10"
+        className="bg-secondary-50 mx-auto w-full max-w-[1200px] px-4 py-6 sm:px-6 sm:py-10 lg:px-[100px]"
       >
         <PageHeader />
 
@@ -162,7 +148,6 @@ export function GatheringListPage({
             tabs={topTabs}
             selectedTab={selectedTopTab}
             onChange={(tab) => {
-              console.log("🖱️ [탭 클릭]", tab.label);
               setSelectedChip(null); // 먼저 칩 초기화
               setSelectedTopTab(tab); // 그 다음 탭 바꿈
             }}
@@ -177,14 +162,13 @@ export function GatheringListPage({
 
         {/* 칩 렌더링 */}
         {chips.length > 0 && (
-          <div className="mt-3.5 flex flex-wrap gap-2">
+          <div className="mt-2.5 flex flex-wrap gap-2 sm:mt-3.5">
             {chips.map(({ label, value }) => (
               <Chip
                 key={value}
                 label={label}
                 selected={selectedChip?.value === value}
                 onClick={() => {
-                  console.log("🔹 [칩 클릭]", label);
                   setSelectedChip({ label, value });
 
                   const formattedDate = getFormattedDate(filters.date);
@@ -202,13 +186,12 @@ export function GatheringListPage({
                     setHasMore(true); // 무한스크롤 다시 가능
                   });
                 }}
-                size="md"
               />
             ))}
           </div>
         )}
 
-        <div className="mt-4 border-t-2 border-gray-200 pt-4">
+        <div className="mt-4 border-t-2 border-gray-200 pt-3 sm:pt-4">
           <FilterBar
             sortOptions={mainSortOptions}
             defaultSortValue="latest"
@@ -221,8 +204,11 @@ export function GatheringListPage({
         <div className="mt-6 flex flex-col gap-4">
           {gatherings.length === 0 ? (
             <div className="flex min-h-[300px] flex-col items-center justify-center text-center text-gray-500">
-              <p>아직 모임이 없어요,</p>
-              <p>지금 바로 모임을 만들어보세요</p>
+              <p className="leading-lg">
+                아직 모임이 없어요.
+                <br />
+                지금 바로 모임을 만들어보세요!
+              </p>
             </div>
           ) : (
             gatherings.map((gathering, index) => (

--- a/src/components/atom/chip/index.tsx
+++ b/src/components/atom/chip/index.tsx
@@ -3,28 +3,23 @@ import clsx from "clsx";
 
 // 프롭스 인터페이스
 interface ChipProps {
-  label: string;              // Chip에 표시될 텍스트
-  selected: boolean;          // 선택 상태 여부 (true: 선택됨, false: 미선택)
-  onClick: () => void;        // 클릭 시 실행할 함수
-  size?: "sm" | "md";         // 크기 옵션 (기본값은 "md")
+  label: string; // Chip에 표시될 텍스트
+  selected: boolean; // 선택 상태 여부 (true: 선택됨, false: 미선택)
+  onClick: () => void; // 클릭 시 실행할 함수
 }
 
 // 칩 컴포넌트 정의
-export const Chip = ({ label, selected, onClick, size = "md" }: ChipProps) => {
-  const sizeClass = {
-    sm: "px-3 py-2 text-sm",        // 좌우 12px, 상하 8px, 폰트 14px
-    md: "px-4 py-[10px] text-sm",   // 좌우 16px, 상하 10px, 폰트 14px
-  }[size];
-
+export const Chip = ({ label, selected, onClick }: ChipProps) => {
   return (
     <button
       onClick={onClick}
       className={clsx(
-        "rounded-xl cursor-pointer transition",
-        sizeClass,
+        "cursor-pointer rounded-xl transition",
+        "px-3 py-2 text-sm", // 모바일 기본
+        "sm:px-4 sm:py-[10px]", // 태블릿 이상
         selected
-          ? "bg-gray-900 text-white"      // 선택됨: 어두운 배경 + 흰 글씨
-          : "bg-gray-200 text-gray-900"   // 미선택: 밝은 배경 + 어두운 글씨
+          ? "bg-gray-900 text-white" // 선택됨: 어두운 배경 + 흰 글씨
+          : "bg-gray-200 text-gray-900", // 미선택: 밝은 배경 + 어두운 글씨
       )}
       role="button"
     >

--- a/src/components/atom/dropdown/index.tsx
+++ b/src/components/atom/dropdown/index.tsx
@@ -63,8 +63,14 @@ export const Dropdown = ({
       ? selectedOption?.label || placeholder
       : placeholder;
 
-  const sizeClass = {
-    // 드롭다운 너비 설정
+  const triggerSizeClass = {
+    sm: "min-w-0",
+    md: "sm:min-w-[110px]",
+    lg: "sm:min-w-[142px]",
+    full: "w-full",
+  }[size];
+
+  const dropdownListSizeClass = {
     sm: "min-w-[80px]",
     md: "min-w-[110px]",
     lg: "min-w-[142px]",
@@ -155,7 +161,7 @@ export const Dropdown = ({
           aria-expanded={isOpen}
           className={clsx(
             "flex cursor-pointer items-center rounded-xl px-3 py-2 text-sm",
-            sizeClass,
+            triggerSizeClass,
             {
               // 높이 설정
               "h-10": size !== "full",
@@ -199,9 +205,18 @@ export const Dropdown = ({
           )}
         >
           {icon?.position === "left" && (
-            <span className="mr-2">{renderIcon()}</span>
+            <span className="sm:mr-2">{renderIcon()}</span>
           )}
-          <span className="truncate">{selectedLabel}</span>
+          <span
+            className={clsx(
+              "truncate",
+              icon?.position === "left"
+                ? "hidden sm:inline-block"
+                : "inline-block",
+            )}
+          >
+            {selectedLabel}
+          </span>
           {icon?.position !== "left" && (
             <span className="ml-2">{renderIcon()}</span>
           )}
@@ -214,7 +229,7 @@ export const Dropdown = ({
           ref={dropdownRef}
           className={clsx(
             "absolute z-10 mt-2 w-full overflow-hidden rounded-xl bg-white shadow-xl",
-            sizeClass,
+            dropdownListSizeClass,
             customListClassName,
           )}
         >

--- a/src/components/molecules/filterBar/index.tsx
+++ b/src/components/molecules/filterBar/index.tsx
@@ -116,7 +116,7 @@ export const FilterBar = ({
           {isCalendarOpen && (
             <div
               ref={calendarWrapperRef}
-              className="absolute z-20 mt-2 w-[336px] rounded-xl bg-white px-[10px] pt-6 pb-6 shadow-xl"
+              className="fixed left-1/2 z-50 w-[336px] -translate-x-1/2 rounded-xl bg-white px-[10px] pt-6 pb-6 shadow-xl sm:absolute sm:top-auto sm:left-auto sm:translate-x-0"
             >
               <div className="mx-auto w-[250px]">
                 <Calendar
@@ -150,6 +150,7 @@ export const FilterBar = ({
         icon={{ name: "sort", position: "left" }}
         activeStyle="light"
         size="md"
+        customListClassName="right-0 sm:left-0"
       />
     </div>
   );

--- a/src/components/molecules/gatheringCard/index.tsx
+++ b/src/components/molecules/gatheringCard/index.tsx
@@ -29,14 +29,15 @@ export const GatheringCard = ({
     <article
       onClick={onClick}
       className={clsx(
-        "border-secondary-100 relative flex cursor-pointer flex-row overflow-hidden rounded-3xl border-2 bg-white transition",
+        "border-secondary-100 relative flex cursor-pointer overflow-hidden rounded-3xl border-2 bg-white transition",
+        "flex-col sm:flex-row",
         {
           "pointer-events-none": isDimmed,
         },
       )}
     >
       {/* 썸네일 이미지 */}
-      <div className="relative h-[156px] w-72">
+      <div className="relative h-[156px] w-full sm:w-72">
         <img
           src={gathering.image || "/image/alt-place.jpg"}
           alt={gathering.name}
@@ -46,16 +47,21 @@ export const GatheringCard = ({
       </div>
 
       {/* 우측 본문 */}
-      <div className="flex flex-1 flex-col justify-between">
+      <div className="flex flex-1 flex-col justify-between gap-6 p-4 sm:gap-0 sm:pt-4 sm:pr-4 sm:pb-4 sm:pl-6">
         {/* 카드 헤더 그룹 */}
-        <div className="flex items-start justify-between pt-4 pr-4 pb-[21px] pl-6">
+        <div className="flex items-start justify-between gap-2">
           {/* 텍스트 정보 영역 */}
-          <div className="flex flex-col gap-2">
-            <header className="flex items-center">
-              <h3 className="text-lg font-semibold text-gray-900 after:mx-2 after:content-['|']">
+          <div className="flex min-w-0 flex-col gap-2">
+            <header className="flex min-w-0 items-center">
+              <h3 className="text-secondary-900 min-w-0 truncate text-lg font-semibold">
                 {gathering.name}
               </h3>
-              <p className="text-gray-400">{gathering.location}</p>
+              <span className="text-secondary-500 mx-2 text-sm sm:text-lg">
+                |
+              </span>
+              <p className="text-secondary-700 min-w-0 truncate">
+                {gathering.location}
+              </p>
             </header>
 
             <div className="flex items-center gap-2">
@@ -70,15 +76,17 @@ export const GatheringCard = ({
 
           {/* 찜 or 바이콘 */}
           {isDimmed ? (
-            <div className="bg-heart-base z-30 flex size-11 items-center justify-center rounded-full">
+            <div className="bg-heart-base z-30 flex size-11 shrink-0 items-center justify-center rounded-full">
               <ByeIcon className="h-6 w-6" />
             </div>
           ) : (
-            <LikeButton gatheringId={gathering.id} />
+            <div className="shrink-0">
+              <LikeButton gatheringId={gathering.id} />
+            </div>
           )}
         </div>
 
-        <div className="flex items-end justify-between gap-6 pt-2 pr-6 pb-4 pl-6">
+        <div className="flex items-end justify-between gap-6">
           {/* 좌측 */}
           <div className="flex flex-1 flex-col gap-2">
             <div

--- a/src/components/molecules/pageHeader/index.tsx
+++ b/src/components/molecules/pageHeader/index.tsx
@@ -11,9 +11,9 @@ export const PageHeader = () => {
       {/* 텍스트 영역 */}
       <div className="flex flex-col justify-center">
         <p className="text-secondary-700 mb-2">함께 할 사람이 없나요?</p>
-        <h2 className="text-secondary-900 leading-none">
+        <h3 className="text-secondary-900 text-lg leading-none font-semibold sm:text-2xl">
           지금 모임에 참여해보세요
-        </h2>
+        </h3>
       </div>
     </div>
   );

--- a/src/effect/gatherings/getGatheringList.ts
+++ b/src/effect/gatherings/getGatheringList.ts
@@ -3,6 +3,7 @@
 
 import type { Gathering } from "@/entity/gathering";
 
+// API 기본 URL과 팀 ID
 const BASE_URL = "https://fe-adv-project-together-dallaem.vercel.app";
 const TEAM_ID = "slotest";
 
@@ -10,37 +11,42 @@ export const getGatheringList = async (
   offset: number,
   limit: number,
   filters?: {
-    region?: string;
-    date?: string;
-    sortBy?: string;
-    sortOrder?: "asc" | "desc";
-    type?: string;
+    region?: string; // 지역 필터
+    date?: string; // 날짜 필터
+    sortBy?: string; // 정렬 기준 필드명
+    sortOrder?: "asc" | "desc"; // 정렬 순서
+    type?: string; // 모임 타입(상위/하위 카테고리)
   },
 ) => {
   const params = new URLSearchParams();
   params.append("offset", offset.toString());
   params.append("limit", limit.toString());
 
+  // 선택한 지역 필터 추가
   if (filters?.region && filters.region !== "all") {
     params.append("location", filters.region);
   }
+  // 선택한 날짜 필터 추가
   if (filters?.date) {
     params.append("date", filters.date);
   }
+  // 선택한 정렬 필드 추가
   if (filters?.sortBy) {
     params.append("sortBy", filters.sortBy);
   }
+  // 선택한 정렬 순서 추가
   if (filters?.sortOrder) {
     params.append("sortOrder", filters.sortOrder);
   }
+  // 선택한 모임 타입 필터 추가
   if (filters?.type) {
     params.append("type", filters.type);
   }
-
+  // API 호출
   const response = await fetch(
     `${BASE_URL}/${TEAM_ID}/gatherings?${params.toString()}`,
     {
-      cache: "no-store",
+      cache: "no-store", // 캐시를 사용하지 않고 항상 최신 데이터를 가져옴
     },
   );
 
@@ -48,6 +54,11 @@ export const getGatheringList = async (
     throw new Error("모임 목록을 불러오는 데 실패했습니다");
   }
 
+  // 받아온 데이터
   const data: Gathering[] = await response.json();
-  return data.filter((item) => item.canceledAt === null);
+  const now = new Date(); // 현재 시각
+  // 취소되지 않았고, 현재 시각 이후에 열리는 모임만 필터링
+  return data.filter(
+    (item) => item.canceledAt === null && new Date(item.dateTime) > now,
+  );
 };


### PR DESCRIPTION
## 작업 내용
- 페이지 헤더 (PageHeader)
  - 모바일 반응형 폰트 사이즈 조정
- 필터바 (FilterBar)
  - 정렬 버튼 텍스트 모바일 숨김 및 아이콘만 표시
  - 정렬 드롭다운 모바일 right 정렬
  - 캘린더 팝업 모바일 가운데 정렬
- 모임 카드 (GatheringCard)
  - 모바일 반응형 레이아웃 (이미지 상단)
  - 모임명, 장소 말줄임 처리
  - 찜 버튼(하트) 크기 고정
- 모임 리스트 (GatheringListPage)
  - 종료된 모임 비노출 처리

Closes #119
Closes #102 