### PR TITLE
refactor: 정렬 옵션 수정 및 상수 정리 (#151)

### DIFF
--- a/src/components/molecules/calendar/index.tsx
+++ b/src/components/molecules/calendar/index.tsx
@@ -24,10 +24,18 @@ const MONTHS_IN_YEAR = 12; // 1년은 12개월
 const DAYS_IN_WEEK = 7; // 1주는 7일
 const HOUR_ITEMS = Array.from({ length: HOURS_IN_HALF_DAY }, (_, i) =>
   String(i + 1).padStart(2, "0"),
-); // 1~12시까지의 시간 항목
+);
 const MINUTE_ITEMS = Array.from({ length: 60 / 5 }, (_, i) =>
   String(i * 5).padStart(2, "0"),
-); // 0~55분까지 5분 단위로 분 항목 생성
+);
+
+const today = dayjs();
+const formattedMonths = Array.from({ length: MONTHS_IN_YEAR }, (_, i) =>
+  dayjs().month(i).format("MMM"),
+);
+const formattedWeekdays = Array.from({ length: DAYS_IN_WEEK }, (_, i) =>
+  dayjs().day(i).format("ddd"),
+);
 
 export const Calendar = ({
   mode,
@@ -36,7 +44,6 @@ export const Calendar = ({
   onApply,
   onReset,
 }: CalendarProps) => {
-  const today = dayjs(); // 오늘 날짜
   const [currentMonth, setCurrentMonth] = useState<Dayjs>(today); // 현재 표시 중인 월 (기본값: 오늘)
   const [localSelectedDate, setLocalSelectedDate] = useState<Dayjs | null>(
     selectedDate ? dayjs(selectedDate) : today,
@@ -141,14 +148,6 @@ export const Calendar = ({
     const day = index - startDay + 1;
     return day > 0 ? day : null;
   });
-
-  // 월과 요일 포맷팅
-  const formattedMonths = Array.from({ length: MONTHS_IN_YEAR }, (_, i) =>
-    dayjs().month(i).format("MMM"),
-  );
-  const formattedWeekdays = Array.from({ length: DAYS_IN_WEEK }, (_, i) =>
-    dayjs().day(i).format("ddd"),
-  );
 
   return (
     <div>

--- a/src/components/molecules/gatheringListPage/index.tsx
+++ b/src/components/molecules/gatheringListPage/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useInView } from "react-intersection-observer";
+
 import { getGatheringList } from "@/effect/gatherings/getGatheringList";
 import { GatheringCard } from "@/components/molecules/gatheringCard";
 import { Button } from "@/components/atom/button";
@@ -31,7 +32,6 @@ const subTabs: Record<string, { label: string; value: string }[]> = {
 
 // 정렬 옵션
 const mainSortOptions: SortOption[] = [
-  { label: "최신 순", value: "latest", sortBy: "dateTime", sortOrder: "desc" },
   {
     label: "마감 임박",
     value: "closingSoon",
@@ -57,6 +57,9 @@ interface GatheringListPageProps {
   initialGatherings: Gathering[];
 }
 
+// 상수 정의
+const PAGE_SIZE = 10; // 한번에 가져오는 pagination 단위
+
 export function GatheringListPage({
   initialGatherings,
 }: GatheringListPageProps) {
@@ -69,7 +72,7 @@ export function GatheringListPage({
     value: string;
   } | null>(null);
   const [gatherings, setGatherings] = useState(initialGatherings);
-  const [skip, setSkip] = useState(10);
+  const [skip, setSkip] = useState(PAGE_SIZE);
   const [hasMore, setHasMore] = useState(true);
   const [filters, setFilters] = useState<Filters>({
     region: "all",
@@ -103,7 +106,7 @@ export function GatheringListPage({
   useEffect(() => {
     const formattedDate = getFormattedDate(filters.date);
 
-    getGatheringList(0, 10, {
+    getGatheringList(0, PAGE_SIZE, {
       region: filters.region !== "all" ? filters.region : undefined,
       date: formattedDate,
       sortBy: filters.sort.sortBy,
@@ -111,7 +114,7 @@ export function GatheringListPage({
       type: selectedChip?.value ?? selectedTopTab.value,
     }).then((newData) => {
       setGatherings(newData);
-      setSkip(10);
+      setSkip(PAGE_SIZE);
       setHasMore(true);
     });
   }, [filters, selectedTopTab, selectedChip?.value]);
@@ -119,7 +122,7 @@ export function GatheringListPage({
   useEffect(() => {
     if (inView && hasMore) {
       const formattedDate = getFormattedDate(filters.date);
-      getGatheringList(skip, 10, {
+      getGatheringList(skip, PAGE_SIZE, {
         region: filters.region !== "all" ? filters.region : undefined,
         date: formattedDate,
         sortBy: filters.sort.sortBy,
@@ -130,7 +133,7 @@ export function GatheringListPage({
           setHasMore(false);
         } else {
           setGatherings((prev) => [...prev, ...newData]);
-          setSkip((prev) => prev + 10);
+          setSkip((prev) => prev + PAGE_SIZE);
         }
       });
     }
@@ -176,7 +179,7 @@ export function GatheringListPage({
 
                   const formattedDate = getFormattedDate(filters.date);
 
-                  getGatheringList(0, 10, {
+                  getGatheringList(0, PAGE_SIZE, {
                     region:
                       filters.region !== "all" ? filters.region : undefined,
                     date: formattedDate,
@@ -185,7 +188,7 @@ export function GatheringListPage({
                     type: value, // 클릭한 칩의 value로 API 호출
                   }).then((newData) => {
                     setGatherings(newData); // 새 데이터로 덮어쓰기
-                    setSkip(10); // skip 초기화
+                    setSkip(PAGE_SIZE); // skip 초기화
                     setHasMore(true); // 무한스크롤 다시 가능
                   });
                 }}
@@ -197,7 +200,7 @@ export function GatheringListPage({
         <div className="mt-4 border-t-2 border-gray-200 pt-3 sm:pt-4">
           <FilterBar
             sortOptions={mainSortOptions}
-            defaultSortValue="latest"
+            defaultSortValue="closingSoon"
             onFilterChange={({ region, date, sort }) => {
               setFilters({ region, date, sort });
             }}


### PR DESCRIPTION
### 작업 항목  
- 정렬 옵션에서 `최신순` 항목 삭제  
- `10`이라는 하드코딩된 값을 `PAGE_SIZE` 상수로 정의
- 렌더링 최적화를 위한 상수 위치 이동 (today, formattedMonths, formattedWeekdays)

Closes #151
