### PR TITLE
fix: 상세페이지 관련 에러 핸들링 (#153)

### DIFF
--- a/src/app/(detail)/gathering/[id]/page.tsx
+++ b/src/app/(detail)/gathering/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function Page({
   // 특정 모임의 참가자 목록 조회 (avatarList용)
   const participantAvatars = await getParticipants(id);
   // 리뷰 목록 조회
-  const reviewList = await getReviews({ gatheringId: id, offset: 0 });
+  const reviewList = await getReviews({ gatheringId: id, limit: 4 });
 
   return (
     <>

--- a/src/components/atom/progressBar/index.tsx
+++ b/src/components/atom/progressBar/index.tsx
@@ -24,7 +24,7 @@ export const ProgressBar = ({
     >
       <motion.div
         className={clsx("h-full rounded-md", {
-          "bg-primary-400": isColored && totalCount === currentCount,
+          "bg-primary-300": isColored && totalCount === currentCount,
           "bg-primary-600": isColored && totalCount !== currentCount,
           "bg-secondary-600": !isColored,
         })}

--- a/src/components/molecules/bottomFloatingBar/bottomFloatingBarWrapper.tsx
+++ b/src/components/molecules/bottomFloatingBar/bottomFloatingBarWrapper.tsx
@@ -23,7 +23,7 @@ export const BottomFloatingBarWrapper = ({
   hostId,
 }: BottomFloatingBarWrapperrProps) => {
   const router = useRouter();
-  const { user } = useUserStore();
+  const { user, setUser } = useUserStore();
   const [isJoined, setIsJoined] = useState(false); // 로그인 유저의 참여 여부
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -31,6 +31,7 @@ export const BottomFloatingBarWrapper = ({
 
   // 로그인 유저의 참여 여부 체크
   useEffect(() => {
+    if (!user) return;
     const checkJoinedStatus = async () => {
       try {
         const response = await getJoinedGatherings({});
@@ -40,6 +41,12 @@ export const BottomFloatingBarWrapper = ({
         setIsJoined(joined);
       } catch (error) {
         if (axios.isAxiosError(error)) {
+          if (error.response?.status === 401) {
+            console.log("✅error:", error.response?.status);
+            setUser(null);
+            localStorage.removeItem("token");
+            return;
+          }
           toast.error(error.response?.data.message);
         } else {
           toast.error("참여 여부 체크에 실패했습니다");
@@ -54,7 +61,10 @@ export const BottomFloatingBarWrapper = ({
     // 버튼 포커스 제거
     const activeElement = document.activeElement as HTMLElement | null;
     activeElement?.blur();
-
+    if (!user) {
+      setIsModalOpen(true);
+      return;
+    }
     try {
       const joinResult = await joinGathering(gatheringId);
       if (joinResult.message) {
@@ -64,11 +74,9 @@ export const BottomFloatingBarWrapper = ({
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        toast.error(
-          error.response?.data.message || "모임참여여에 실패했습니다",
-        );
+        toast.error(error.response?.data.message || "모임참여에 실패했습니다");
       } else {
-        toast.error("모임참여여에 실패했습니다");
+        toast.error("모임참여에 실패했습니다");
       }
     }
   };

--- a/src/components/molecules/gatheringCard/index.tsx
+++ b/src/components/molecules/gatheringCard/index.tsx
@@ -125,7 +125,7 @@ export const GatheringCard = ({
           {/* 우측 CTA 또는 종료 안내 */}
           <div className="flex-shrink-0">
             {isFull ? (
-              <div className="text-primary-600 text-sm font-semibold">
+              <div className="text-primary-400 text-sm font-semibold">
                 Closed
               </div>
             ) : (


### PR DESCRIPTION
## 작업내용
- 상세페이지 리뷰 초기 fetch에 limit param 추가
- 비로그인 유저는 참여 여부 확인하지 않도록 처리
- 토큰인증에 실패할 경우 로그인 정보 지우도록 처리

### 기타
- gatheringCard에서 isFull 인 경우, 텍스트 색상 및 progressBar 색상 변경하였습니다

Closes #153 