### PR TITLE
[feature] CategoryTab 컴포넌트 구현 (#160)

### DIFF
--- a/src/components/molecules/categoryTab/index.tsx
+++ b/src/components/molecules/categoryTab/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { Tabs } from "@/components/atom/tabs";
+import { Chip } from "@/components/atom/chip";
+import { useEffect, useState } from "react";
+import { TOP_CATEGORY, SUB_CATEGORY } from "@/constants/category";
+
+interface CategoryTabProps {
+  setSelectedType: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export const CategoryTab = ({ setSelectedType }: CategoryTabProps) => {
+  const [selectedTopTab, setSelectedTopTab] = useState(TOP_CATEGORY[0]);
+  const [selectedChip, setSelectedChip] = useState<{
+    label: string;
+    value: string;
+  } | null>(SUB_CATEGORY[TOP_CATEGORY[0].value][0]);
+  const chips = SUB_CATEGORY[selectedTopTab.value];
+  useEffect(() => {
+    if (!selectedChip) {
+      setSelectedType(selectedTopTab.value);
+      return;
+    }
+    setSelectedType(selectedChip.value);
+  }, [selectedTopTab, selectedChip, setSelectedType]);
+  return (
+    <div>
+      <Tabs
+        tabs={TOP_CATEGORY}
+        selectedTab={selectedTopTab}
+        onChange={(tab) => {
+          setSelectedTopTab(tab);
+          setSelectedChip(SUB_CATEGORY[tab.value][0] || null);
+        }}
+      />
+      {chips.length > 0 && (
+        <div className="mt-2.5 flex flex-wrap gap-2 sm:mt-3.5">
+          {chips.map(({ label, value }) => (
+            <Chip
+              key={value}
+              label={label}
+              selected={selectedChip?.value === value}
+              onClick={() => {
+                setSelectedChip({ label, value });
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/constants/category.ts
+++ b/src/constants/category.ts
@@ -1,0 +1,20 @@
+import { type Tab } from "@/components/atom/tabs";
+
+// 상위 탭
+export const TOP_CATEGORY: Tab[] = [
+  { label: "마인드풀니스", value: "DALLAEMFIT", icon: "meditation" },
+  { label: "원데이클래스", value: "WORKATION", icon: "vacation" },
+];
+
+// 하위 탭
+export const SUB_CATEGORY: Record<string, { label: string; value: string }[]> =
+  {
+    DALLAEMFIT: [
+      { label: "전체", value: "DALLAEMFIT" },
+      { label: "요가", value: "OFFICE_STRETCHING" },
+      { label: "명상", value: "MINDFULNESS" },
+    ],
+    WORKATION: [], // 워케이션은 하위 카테고리 없음
+  };
+
+export const DEFAULT_TYPE = SUB_CATEGORY[TOP_CATEGORY[0].value][0].value;


### PR DESCRIPTION
## 작업내용
- 카테고리 종류 상수로 정의했습니다. (마인드풀니스/요가/명상/원데이클래스)
- CategoryTab 컴포넌트 구현

## 기타
해당 컴포넌트를 사용 할 부모 컴포넌트에는 아래와 같이 정의한 후, setSelectedType을 전달하면 됩니다.
const [selectedType, setSelectedType] = useState(DEFAULT_TYPE);
이 때, selectedType은 "DALLEMPIT" 과 같이 카테고리 값만 들어갑니다.

Closes #160 