### PR TITLE
Feature/reviews

### DIFF
--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -2,10 +2,10 @@ import { ReviewHeaderIcon } from "@/components/icons/ReviewHeaderIcon";
 import { getReviews } from "@/effect/reviews/getReviews";
 import { getScores } from "@/effect/reviews/getScores";
 import { ReviewPageContent } from "@/components/organisms/reviewPageContent";
-
+import { DEFAULT_TYPE } from "@/constants/category";
 export default async function ReviewsPage() {
-  const scores = await getScores({});
-  const reviews = await getReviews({ limit: 5 });
+  const scores = await getScores({ type: DEFAULT_TYPE });
+  const reviews = await getReviews({ type: DEFAULT_TYPE, limit: 5 });
 
   return (
     <main className="flex flex-col items-center bg-gray-100">

--- a/src/components/molecules/categoryTab/index.tsx
+++ b/src/components/molecules/categoryTab/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { Tabs } from "@/components/atom/tabs";
+import { Chip } from "@/components/atom/chip";
+import { useEffect, useState } from "react";
+import { TOP_CATEGORY, SUB_CATEGORY } from "@/constants/category";
+
+interface CategoryTabProps {
+  setSelectedType: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export const CategoryTab = ({ setSelectedType }: CategoryTabProps) => {
+  const [selectedTopTab, setSelectedTopTab] = useState(TOP_CATEGORY[0]);
+  const [selectedChip, setSelectedChip] = useState<{
+    label: string;
+    value: string;
+  } | null>(SUB_CATEGORY[TOP_CATEGORY[0].value][0]);
+  const chips = SUB_CATEGORY[selectedTopTab.value];
+  useEffect(() => {
+    if (!selectedChip) {
+      setSelectedType(selectedTopTab.value);
+      return;
+    }
+    setSelectedType(selectedChip.value);
+  }, [selectedTopTab, selectedChip, setSelectedType]);
+  return (
+    <div>
+      <Tabs
+        tabs={TOP_CATEGORY}
+        selectedTab={selectedTopTab}
+        onChange={(tab) => {
+          setSelectedTopTab(tab);
+          setSelectedChip(SUB_CATEGORY[tab.value][0] || null);
+        }}
+      />
+      {chips.length > 0 && (
+        <div className="mt-2.5 flex flex-wrap gap-2 sm:mt-3.5">
+          {chips.map(({ label, value }) => (
+            <Chip
+              key={value}
+              label={label}
+              selected={selectedChip?.value === value}
+              onClick={() => {
+                setSelectedChip({ label, value });
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/molecules/reviewItem/index.tsx
+++ b/src/components/molecules/reviewItem/index.tsx
@@ -15,7 +15,7 @@ export const ReviewItem = ({
   reviewContent,
 }: ReviewItemProps) => {
   return (
-    <li className="mt-6 flex w-full flex-col items-start gap-6 sm:flex-row sm:items-center">
+    <li className="border-b-secondary-200 flex w-full flex-col items-start gap-6 border-b-2 border-dashed py-6 sm:flex-row sm:items-start">
       {/* 이미지 */}
       {showImage && (
         <div className="relative h-39 w-full overflow-hidden rounded-3xl bg-red-100 sm:max-w-70">
@@ -30,7 +30,7 @@ export const ReviewItem = ({
       )}
 
       {/* 텍스트 */}
-      <div className="border-b-secondary-200 w-full border-b-2 border-dashed pb-4">
+      <div className="w-full">
         <Rating score={reviewContent.score} />
         <p className="text-secondary-700 my-4">{reviewContent.comment}</p>
         <p className="text-secondary-700 text-xs">

--- a/src/components/organisms/ratingOverview/index.tsx
+++ b/src/components/organisms/ratingOverview/index.tsx
@@ -21,7 +21,11 @@ export const RatingOverview = ({ scores }: RatingOverviewProps) => {
         </div>
         <Rating score={scores?.averageScore || 0} />
       </div>
-      <RatingBars scoreSummary={scoreSummary} />
+      <RatingBars
+        scoreSummary={
+          scoreSummary || { totalCount: 1, scoreList: [0, 0, 0, 0, 0] }
+        }
+      />
     </div>
   );
 };

--- a/src/components/organisms/reviewPageContent/index.tsx
+++ b/src/components/organisms/reviewPageContent/index.tsx
@@ -1,9 +1,13 @@
 "use client";
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { RatingOverview } from "../ratingOverview";
 import { Scores } from "@/entity/scores";
 import { ReviewDetail } from "@/entity/review";
 import { ReviewsWithInfiniteScroll } from "../reviewsWithInfiniteScroll";
+import { getReviews } from "@/effect/reviews/getReviews";
+import { CategoryTab } from "@/components/molecules/categoryTab";
+import { DEFAULT_TYPE } from "@/constants/category";
+import { getScores } from "@/effect/reviews/getScores";
 
 interface ReviewPageContentProps {
   initialReviews: ReviewDetail[];
@@ -14,13 +18,35 @@ export const ReviewPageContent = ({
   initialReviews,
   initalScore,
 }: ReviewPageContentProps) => {
-  const memoizedReviews = useMemo(() => initialReviews, [initialReviews]);
-  const [scores] = useState<Scores>(initalScore);
+  const [selectedType, setSelectedType] = useState(DEFAULT_TYPE);
+  const [reviews, setReviews] = useState(initialReviews);
+  const [scores, setScores] = useState<Scores>(initalScore);
 
+  useEffect(() => {
+    const reloadInitialData = async () => {
+      const newScoresData = await getScores({ type: selectedType });
+      setScores(newScoresData[0]);
+
+      const newReviewsData = await getReviews({
+        type: selectedType,
+        limit: 5,
+      });
+
+      setReviews(newReviewsData.data);
+    };
+    reloadInitialData();
+  }, [selectedType]);
   return (
     <>
-      <div>{scores && <RatingOverview scores={scores} />}</div>
-      <ReviewsWithInfiniteScroll initialReviews={memoizedReviews} />
+      <div className="border-b-secondary-200 border-b-2 pb-2.5 sm:pb-3.5">
+        <CategoryTab setSelectedType={setSelectedType} />
+      </div>
+
+      <RatingOverview scores={scores} />
+      <ReviewsWithInfiniteScroll
+        initialReviews={reviews}
+        selectedType={selectedType}
+      />
     </>
   );
 };

--- a/src/components/organisms/reviewsWithInfiniteScroll/index.tsx
+++ b/src/components/organisms/reviewsWithInfiniteScroll/index.tsx
@@ -2,48 +2,55 @@
 import { ReviewDetail } from "@/entity/review";
 import { ReviewList } from "../reveiwList";
 import { useInView } from "react-intersection-observer";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { getReviews } from "@/effect/reviews/getReviews";
 
 interface ReviewDetailProps {
   initialReviews: ReviewDetail[];
+  selectedType: string;
 }
 
 const REVIEW_LIMIT = 5;
 
 export const ReviewsWithInfiniteScroll = ({
   initialReviews,
+  selectedType,
 }: ReviewDetailProps) => {
-  const [reviews, setReviews] = useState(initialReviews);
+  const [reviews, setReviews] = useState<ReviewDetail[]>([]);
   const [offset, setOffset] = useState(REVIEW_LIMIT);
   const [hasMore, setHasMore] = useState(true);
   const { ref, inView } = useInView({ threshold: 0.5 });
 
-  const loadMoreReviews = async () => {
-    console.log("✅loadMoreReviews 데이터 더 로딩 ");
+  useEffect(() => {
+    setReviews(initialReviews);
+    setHasMore(true);
+  }, [initialReviews, selectedType]);
 
+  const loadMoreReviews = useCallback(async () => {
     const newReviews = await getReviews({
       limit: REVIEW_LIMIT,
       offset: offset,
+      type: selectedType,
     });
+
     setReviews((prevReviews) => [...prevReviews, ...newReviews.data]);
     setOffset((prev) => prev + REVIEW_LIMIT);
+
     if (newReviews.currentPage === newReviews.totalPages) {
       setHasMore(false);
     }
-  };
+  }, [offset, selectedType]);
 
   useEffect(() => {
     if (inView && hasMore) {
       loadMoreReviews();
     }
-  }, [inView, hasMore]);
+  }, [inView, hasMore, loadMoreReviews]);
 
   return (
-    // height 조절 필요
-    <div className="border-secondary-900 flex h-full min-h-[800px] w-full flex-col border-t-2 bg-white px-4 pt-6 sm:px-6">
-      {!initialReviews ? (
-        <div className="flex h-full w-full items-center justify-center">
+    <div className="border-secondary-900 flex h-full min-h-[750px] w-full flex-col border-t-2 bg-white px-4 pt-6 sm:px-6">
+      {!initialReviews || initialReviews.length < 1 ? (
+        <div className="my-auto flex w-full items-center justify-center">
           <p className="text-secondary-500">아직 리뷰가 없어요</p>
         </div>
       ) : (

--- a/src/constants/category.ts
+++ b/src/constants/category.ts
@@ -1,0 +1,20 @@
+import { type Tab } from "@/components/atom/tabs";
+
+// 상위 탭
+export const TOP_CATEGORY: Tab[] = [
+  { label: "마인드풀니스", value: "DALLAEMFIT", icon: "meditation" },
+  { label: "원데이클래스", value: "WORKATION", icon: "vacation" },
+];
+
+// 하위 탭
+export const SUB_CATEGORY: Record<string, { label: string; value: string }[]> =
+  {
+    DALLAEMFIT: [
+      { label: "전체", value: "DALLAEMFIT" },
+      { label: "요가", value: "OFFICE_STRETCHING" },
+      { label: "명상", value: "MINDFULNESS" },
+    ],
+    WORKATION: [], // 워케이션은 하위 카테고리 없음
+  };
+
+export const DEFAULT_TYPE = SUB_CATEGORY[TOP_CATEGORY[0].value][0].value;


### PR DESCRIPTION
## 작업내용
- CategoryTab 컴포넌트 구현
> - 카테고리 종류 상수로 정의했습니다. (마인드풀니스/요가/명상/원데이클래스)
- 해당 컴포넌트 사용하여 리뷰페이지 추가 구현
- review 없을 경우 score 영역 나타나지 않던 것 수정 (빈 데이터로 나타나도록)
- ReviewItem 스타일 일부 수정

### 기타
CategoryTab 를 사용 할 부모 컴포넌트에는 아래와 같이 정의한 후, setSelectedType을 전달하면 됩니다.
const [selectedType, setSelectedType] = useState(DEFAULT_TYPE);
이 때, selectedType은 "DALLEMPIT" 과 같이 카테고리 값만 들어갑니다.
(src/components/organisms/reviewPageContent/index.tsx 참고!)

Related to #123
Closes #160 