### PR TITLE
feature: reviews - FillterBar 적용 및 필터링 구현 (#123)

### DIFF
--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -5,7 +5,7 @@ import { ReviewPageContent } from "@/components/organisms/reviewPageContent";
 import { DEFAULT_TYPE } from "@/constants/category";
 export default async function ReviewsPage() {
   const scores = await getScores({ type: DEFAULT_TYPE });
-  const reviews = await getReviews({ type: DEFAULT_TYPE, limit: 5 });
+  const reviews = await getReviews({ type: DEFAULT_TYPE, limit: 10 });
 
   return (
     <main className="flex flex-col items-center bg-gray-100">

--- a/src/components/organisms/reviewPageContent/index.tsx
+++ b/src/components/organisms/reviewPageContent/index.tsx
@@ -8,6 +8,9 @@ import { getReviews } from "@/effect/reviews/getReviews";
 import { CategoryTab } from "@/components/molecules/categoryTab";
 import { DEFAULT_TYPE } from "@/constants/category";
 import { getScores } from "@/effect/reviews/getScores";
+import { Filters } from "@/entity/filters";
+import { reviewsSortOptions } from "@/constants/sortOptions";
+import { getFormattedDate } from "@/libs/date/getFormattedDate";
 
 interface ReviewPageContentProps {
   initialReviews: ReviewDetail[];
@@ -21,6 +24,11 @@ export const ReviewPageContent = ({
   const [selectedType, setSelectedType] = useState(DEFAULT_TYPE);
   const [reviews, setReviews] = useState(initialReviews);
   const [scores, setScores] = useState<Scores>(initalScore);
+  const [filters, setFilters] = useState<Filters>({
+    region: "all",
+    date: null,
+    sort: reviewsSortOptions[0],
+  });
 
   useEffect(() => {
     const reloadInitialData = async () => {
@@ -29,13 +37,16 @@ export const ReviewPageContent = ({
 
       const newReviewsData = await getReviews({
         type: selectedType,
-        limit: 5,
+        location: filters.region === "all" ? undefined : filters.region,
+        date: getFormattedDate(filters.date),
+        sortBy: filters.sort.sortBy,
+        sortOrder: filters.sort.sortOrder,
+        limit: 10,
       });
-
       setReviews(newReviewsData.data);
     };
     reloadInitialData();
-  }, [selectedType]);
+  }, [selectedType, filters]);
   return (
     <>
       <div className="border-b-secondary-200 border-b-2 pb-2.5 sm:pb-3.5">
@@ -46,6 +57,8 @@ export const ReviewPageContent = ({
       <ReviewsWithInfiniteScroll
         initialReviews={reviews}
         selectedType={selectedType}
+        filters={filters}
+        setFilters={setFilters}
       />
     </>
   );

--- a/src/components/organisms/reviewsWithInfiniteScroll/index.tsx
+++ b/src/components/organisms/reviewsWithInfiniteScroll/index.tsx
@@ -4,17 +4,25 @@ import { ReviewList } from "../reveiwList";
 import { useInView } from "react-intersection-observer";
 import { useCallback, useEffect, useState } from "react";
 import { getReviews } from "@/effect/reviews/getReviews";
+import { FilterBar } from "@/components/molecules/filterBar";
+import { Filters } from "@/entity/filters";
+import { reviewsSortOptions } from "@/constants/sortOptions";
+import { getFormattedDate } from "@/libs/date/getFormattedDate";
 
 interface ReviewDetailProps {
   initialReviews: ReviewDetail[];
   selectedType: string;
+  filters: Filters;
+  setFilters: React.Dispatch<React.SetStateAction<Filters>>;
 }
 
-const REVIEW_LIMIT = 5;
+const REVIEW_LIMIT = 10;
 
 export const ReviewsWithInfiniteScroll = ({
   initialReviews,
   selectedType,
+  filters,
+  setFilters,
 }: ReviewDetailProps) => {
   const [reviews, setReviews] = useState<ReviewDetail[]>([]);
   const [offset, setOffset] = useState(REVIEW_LIMIT);
@@ -23,23 +31,31 @@ export const ReviewsWithInfiniteScroll = ({
 
   useEffect(() => {
     setReviews(initialReviews);
+    setOffset(REVIEW_LIMIT);
     setHasMore(true);
-  }, [initialReviews, selectedType]);
+  }, [initialReviews, selectedType, filters]);
 
   const loadMoreReviews = useCallback(async () => {
     const newReviews = await getReviews({
       limit: REVIEW_LIMIT,
       offset: offset,
       type: selectedType,
+      location: filters.region === "all" ? undefined : filters.region,
+      date: getFormattedDate(filters.date),
+      sortBy: filters.sort.sortBy,
+      sortOrder: filters.sort.sortOrder,
     });
-
+    if (newReviews.data.length < 1) {
+      setHasMore(false);
+      return;
+    }
     setReviews((prevReviews) => [...prevReviews, ...newReviews.data]);
     setOffset((prev) => prev + REVIEW_LIMIT);
 
     if (newReviews.currentPage === newReviews.totalPages) {
       setHasMore(false);
     }
-  }, [offset, selectedType]);
+  }, [offset, selectedType, filters]);
 
   useEffect(() => {
     if (inView && hasMore) {
@@ -49,6 +65,13 @@ export const ReviewsWithInfiniteScroll = ({
 
   return (
     <div className="border-secondary-900 flex h-full min-h-[750px] w-full flex-col border-t-2 bg-white px-4 pt-6 sm:px-6">
+      <FilterBar
+        sortOptions={reviewsSortOptions}
+        defaultSortValue="closingSoon"
+        onFilterChange={({ region, date, sort }) => {
+          setFilters({ region, date, sort });
+        }}
+      />
       {!initialReviews || initialReviews.length < 1 ? (
         <div className="my-auto flex w-full items-center justify-center">
           <p className="text-secondary-500">아직 리뷰가 없어요</p>

--- a/src/constants/sortOptions.ts
+++ b/src/constants/sortOptions.ts
@@ -1,0 +1,39 @@
+import { SortOption } from "@/entity/filters";
+
+// 메인페이지 정렬 옵션
+// const mainSortOptions: SortOption[] = [
+//   {
+//     label: "마감 임박",
+//     value: "closingSoon",
+//     sortBy: "registrationEnd",
+//     sortOrder: "asc",
+//   },
+//   {
+//     label: "참여 인원 순",
+//     value: "participants",
+//     sortBy: "participantCount",
+//     sortOrder: "desc",
+//   },
+// ];
+
+// 리뷰페이지 정렬 옵션
+export const reviewsSortOptions: SortOption[] = [
+  {
+    label: "최신 순",
+    value: "createdAt",
+    sortBy: "createdAt",
+    sortOrder: "asc",
+  },
+  {
+    label: "리뷰 높은 순",
+    value: "score",
+    sortBy: "score",
+    sortOrder: "desc",
+  },
+  {
+    label: "참여 인원 순",
+    value: "participants",
+    sortBy: "participantCount",
+    sortOrder: "desc",
+  },
+];

--- a/src/effect/reviews/getReviews.ts
+++ b/src/effect/reviews/getReviews.ts
@@ -7,7 +7,7 @@ interface GetReviewsParams {
   location?: string;
   date?: string; // YYYY-MM-DD
   registrationEnd?: string; // YYYY-MM-DD
-  sortBy?: "createdAt" | "score" | "participantCount";
+  sortBy?: string;
   sortOrder?: "asc" | "desc";
   limit?: number;
   offset?: number;
@@ -32,7 +32,6 @@ export const getReviews = async (
     });
 
     const url = `${process.env.NEXT_PUBLIC_API_URL}/${process.env.NEXT_PUBLIC_TEAM_ID}/reviews?${urlParams.toString()}`;
-
     const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`Failed to fetch reviews. Status: ${response.status}`);

--- a/src/entity/filters.ts
+++ b/src/entity/filters.ts
@@ -1,0 +1,12 @@
+export interface SortOption {
+  label: string;
+  value: string;
+  sortBy: string;
+  sortOrder: "asc" | "desc";
+}
+
+export interface Filters {
+  region: string;
+  date: Date | null;
+  sort: SortOption;
+}

--- a/src/libs/date/getFormattedDate.ts
+++ b/src/libs/date/getFormattedDate.ts
@@ -1,0 +1,5 @@
+export const getFormattedDate = (date: Date | null) => {
+  if (!date) return undefined;
+  const utcDate = new Date(date.getTime() - 9 * 60 * 60 * 1000);
+  return utcDate.toISOString().split("T")[0]; // 'YYYY-MM-DD'
+};


### PR DESCRIPTION
## 작업내용
- 모든 리뷰페이지에 FillterBar를 적용하고 필터링 기능을 구현하였습니다.
- 무한스크롤 로딩 기준 갯수를 5개에서 10개로 변경하였습니다.
- sortOptions, Filters, getFormattedDate를 별도 파일에 분리하였습니다.

### 기타
리뷰 텍스트가 길어질 경우 레이아웃이 깨지는 것에 대해서는 아래 이미지와 같이 수정하였습니다.
> 1. 텍스트 영역 아래쪽에만 뜨던 border를 아이템 전체로 변경하였습니다.
> 2. 텍스트 길이가 달라질때마다 이미지의 세로 위치가 달라지는 것을 윗쪽으로 고정하였습니다.

![image](https://github.com/user-attachments/assets/32ba9aad-9794-4189-bc69-c51a80726b02)


Closes #123 
