### PR TITLE
[Refactor] 상세페이지 리팩토링 (swr 사용)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-hook-form": "^7.56.4",
     "react-intersection-observer": "^9.16.0",
     "react-toastify": "^11.0.5",
+    "swr": "^2.3.3",
     "zustand": "^5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,12 @@ importers:
       react-toastify:
         specifier: ^11.0.5
         version: 11.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      swr:
+        specifier: ^2.3.3
+        version: 2.3.3(react@19.1.0)
       zustand:
         specifier: ^5.0.4
-        version: 5.0.4(@types/react@19.1.4)(react@19.1.0)
+        version: 5.0.4(@types/react@19.1.4)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.8.1
@@ -3383,6 +3386,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.3.3:
+    resolution: {integrity: sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -3545,6 +3553,11 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -7136,6 +7149,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.3.3(react@19.1.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
+
   symbol-tree@3.2.4: {}
 
   tailwindcss@4.1.7: {}
@@ -7319,6 +7338,10 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   util-deprecate@1.0.2: {}
 
@@ -7534,7 +7557,8 @@ snapshots:
 
   zod@3.25.30: {}
 
-  zustand@5.0.4(@types/react@19.1.4)(react@19.1.0):
+  zustand@5.0.4(@types/react@19.1.4)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
     optionalDependencies:
       '@types/react': 19.1.4
       react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)

--- a/src/app/(detail)/gathering/[id]/page.tsx
+++ b/src/app/(detail)/gathering/[id]/page.tsx
@@ -1,14 +1,8 @@
-import { DeadlineTag } from "@/components/atom/deadlineTag";
-import { BottomFloatingBarWrapper } from "@/components/molecules/bottomFloatingBar/bottomFloatingBarWrapper";
-import { GatheringInformation } from "@/components/molecules/gatheringInformation";
-import { ReviewsWithPagination } from "@/components/organisms/reviewsWithPagination";
-import {
-  getGatheringDetail,
-  getParticipants,
-} from "@/effect/gatherings/getGatheringDetail";
+import { getGatheringInfo } from "@/effect/gatherings/getGatheringDetail";
 import { getReviews } from "@/effect/reviews/getReviews";
-import Image from "next/image";
 import { notFound } from "next/navigation";
+import { GatheringDetailPage } from "@/components/organisms/gatheringDetailPage";
+import { SWRConfig } from "swr";
 
 export default async function Page({
   params,
@@ -16,60 +10,28 @@ export default async function Page({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  // 모임 상세 조회
-  const gatheringData = await getGatheringDetail(id);
-  if (!gatheringData) return notFound();
 
-  // 특정 모임의 참가자 목록 조회 (avatarList용)
-  const participantAvatars = await getParticipants(id);
-  // 리뷰 목록 조회
-  const reviewList = await getReviews({ gatheringId: id, limit: 4 });
+  try {
+    // 서버에서 초기 데이터 fetch
+    const [gatheringData, reviewList] = await Promise.all([
+      getGatheringInfo(id),
+      getReviews({ gatheringId: id, limit: 4 }),
+    ]);
 
-  return (
-    <>
-      <div className="flex h-fit flex-col items-center">
-        <div className="bg-secondary-50 flex h-full min-h-screen w-full max-w-[1200px] flex-col items-center px-4 pt-6 sm:px-6 sm:pt-6.5 md:pt-10">
-          {/* 이미지 및 상세정보 */}
-          <div className="grid w-full max-w-[996px] grid-rows-2 gap-4 sm:grid-cols-2 sm:grid-rows-1 md:gap-6">
-            <div className="relative h-full w-full overflow-hidden rounded-3xl">
-              <Image
-                src={gatheringData.image}
-                alt={`image-${gatheringData.name}` || "/image/alt-place.jpg"}
-                fill
-                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 50vw"
-                priority
-                className="object-cover"
-              />
-              <DeadlineTag
-                className="!pr-4"
-                registrationEnd={gatheringData.registrationEnd}
-              />
-            </div>
-            <GatheringInformation
-              gatheringInfo={gatheringData}
-              participantAvatars={participantAvatars}
-            />
-          </div>
-          {/* 리뷰 */}
-          <div className="border-t-secondary-200 mt-4 flex w-full max-w-[996px] grow flex-col border-t-2 bg-white px-7 pt-7 pb-28 sm:mt-5 md:mt-6">
-            <p className="text-secondary-900 h-fit font-semibold sm:text-lg">
-              이용자들은 이 프로그램을 이렇게 느꼈어요!
-            </p>
-            {!reviewList || reviewList.totalItemCount === 0 ? (
-              <div className="flex w-full grow items-center justify-center">
-                <p className="text-secondary-500">아직 리뷰가 없어요</p>
-              </div>
-            ) : (
-              <ReviewsWithPagination
-                gatheringId={gatheringData.id}
-                initialReviews={reviewList.data}
-                totalPages={reviewList.totalPages}
-              />
-            )}
-          </div>
-        </div>
-      </div>
-      <BottomFloatingBarWrapper gathering={gatheringData} />
-    </>
-  );
+    // SWR fallback 데이터 준비
+    const fallbackData = {
+      [`gathering-with-participants-${id}`]: gatheringData,
+    };
+
+    return (
+      <SWRConfig value={{ fallback: fallbackData }}>
+        <GatheringDetailPage gatheringId={id} reviewList={reviewList} />
+      </SWRConfig>
+    );
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === "GatheringNotFoundError") {
+      notFound();
+    }
+    throw error;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,9 +24,7 @@ export default function RootLayout({
         {/* 메인 콘텐츠 */}
         {children}
 
-        <ToastContainer />
-
-
+        <ToastContainer autoClose={2000} />
       </body>
     </html>
   );

--- a/src/components/molecules/bottomFloatingBar/bottomFloatingBarWrapper.tsx
+++ b/src/components/molecules/bottomFloatingBar/bottomFloatingBarWrapper.tsx
@@ -13,6 +13,7 @@ import axios from "axios";
 import { toast } from "react-toastify";
 import dayjs from "dayjs";
 import { Gathering } from "@/entity/gathering";
+import { mutate } from "swr"; // 전역 mutate import
 interface BottomFloatingBarWrapperrProps {
   gathering: Gathering;
 }
@@ -69,7 +70,7 @@ export const BottomFloatingBarWrapper = ({
       if (joinResult.message) {
         toast.success("모임에 참여했습니다");
         setIsJoined(true);
-        router.refresh();
+        await mutate(`gathering-info-${gathering.id}`);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -117,7 +118,7 @@ export const BottomFloatingBarWrapper = ({
       if (leaveResult) {
         toast.success("모임 참여 취소되었습니다.");
         setIsJoined(false);
-        router.refresh();
+        await mutate(`gathering-info-${gathering.id}`);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {

--- a/src/components/molecules/gatheringInformation/avatarList.tsx
+++ b/src/components/molecules/gatheringInformation/avatarList.tsx
@@ -1,5 +1,4 @@
 import { Avatar } from "@/components/atom/avatar";
-import { useEffect, useState } from "react";
 
 export type participantAvatar = {
   id: number;
@@ -16,17 +15,10 @@ export const AvartarList = ({
   participantCount,
   participantAvatars,
 }: AvartarListProps) => {
-  // console.log("✅ participantAvatars:", participantAvatars);
+  const displayparticipantAvatars =
+    participantCount > 5 ? participantAvatars.slice(0, 4) : participantAvatars;
 
-  const [displayparticipantAvatars, setDisaplayparticipantAvatars] =
-    useState(participantAvatars); // 프로필 사진이 보여지는 사용자 리스트
-  const [overNumber, setOverNumber] = useState(0); // 5명 이상일 경우, 숫자로 표기되는 인원 수
-  useEffect(() => {
-    if (participantCount > 5) {
-      setDisaplayparticipantAvatars(participantAvatars.slice(0, 4));
-      setOverNumber(participantCount - 4);
-    }
-  }, [participantAvatars, participantCount]);
+  const overNumber = participantCount > 5 ? participantCount - 4 : 0;
 
   return (
     <div className="flex -space-x-2.5">
@@ -41,7 +33,7 @@ export const AvartarList = ({
 
       {/* 5명 이상일 경우, 숫자로 표기되는 인원 수  */}
       {participantCount > 5 && (
-        <div className="bg-secondary-100 text-secondary-800 flex h-[30px] w-[30px] items-center justify-center rounded-full text-sm font-semibold">
+        <div className="bg-secondary-100 text-secondary-800 z-10 flex h-[30px] w-[30px] items-center justify-center rounded-full text-sm font-semibold">
           +{overNumber}
         </div>
       )}

--- a/src/components/organisms/gatheringDetailPage/index.tsx
+++ b/src/components/organisms/gatheringDetailPage/index.tsx
@@ -1,0 +1,103 @@
+"use client";
+import { DeadlineTag } from "@/components/atom/deadlineTag";
+import { BottomFloatingBarWrapper } from "@/components/molecules/bottomFloatingBar/bottomFloatingBarWrapper";
+import { GatheringInformation } from "@/components/molecules/gatheringInformation";
+import { useGatheringDetail } from "@/hooks/api/useGatheringDetail";
+import Image from "next/image";
+import { ReviewsWithPagination } from "../reviewsWithPagination";
+import { ReviewList } from "@/entity/review";
+import { Modal } from "@/components/atom/modal";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/atom/button";
+import { useRouter } from "next/navigation";
+
+interface GatheringPageClientProps {
+  gatheringId: string;
+  reviewList: ReviewList;
+}
+
+export const GatheringDetailPage = ({
+  gatheringId,
+  reviewList,
+}: GatheringPageClientProps) => {
+  const router = useRouter();
+  const [isCanceledModalOpen, setCanceledModalOpen] = useState(false);
+  const { gathering, participants, isLoading, isError } =
+    useGatheringDetail(gatheringId);
+
+  useEffect(() => {
+    if (gathering?.canceledAt) {
+      console.log("취소된 모임");
+      setCanceledModalOpen(true);
+    }
+  }, [gathering?.canceledAt]);
+
+  if (isError) {
+    throw isError;
+  }
+
+  if (isLoading || !gathering) {
+    return <div>Loading...</div>; // 로딩 스피너 컴포넌트로 교체
+  }
+
+  return (
+    <>
+      <div className="flex h-fit flex-col items-center">
+        <div className="bg-secondary-50 flex h-full min-h-screen w-full max-w-[1200px] flex-col items-center px-4 pt-6 sm:px-6 sm:pt-6.5 md:pt-10">
+          {/* 이미지 및 상세정보 */}
+          <div className="grid w-full max-w-[996px] grid-rows-2 gap-4 sm:grid-cols-2 sm:grid-rows-1 md:gap-6">
+            <div className="relative h-full w-full overflow-hidden rounded-3xl">
+              <Image
+                src={gathering.image || "/image/alt-place.jpg"}
+                alt={`image-${gathering.name}` || "/image/alt-place.jpg"}
+                fill
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 50vw"
+                priority
+                className="object-cover"
+              />
+              <DeadlineTag
+                className="!pr-4"
+                registrationEnd={gathering.registrationEnd}
+              />
+            </div>
+            <GatheringInformation
+              gatheringInfo={gathering}
+              participantAvatars={participants}
+            />
+          </div>
+          <div className="border-t-secondary-200 mt-4 flex w-full max-w-[996px] grow flex-col border-t-2 bg-white px-7 pt-7 pb-28 sm:mt-5 md:mt-6">
+            <p className="text-secondary-900 h-fit font-semibold sm:text-lg">
+              이용자들은 이 프로그램을 이렇게 느꼈어요!
+            </p>
+            {!reviewList || reviewList.totalItemCount === 0 ? (
+              <div className="flex w-full grow items-center justify-center">
+                <p className="text-secondary-500">아직 리뷰가 없어요</p>
+              </div>
+            ) : (
+              <ReviewsWithPagination
+                gatheringId={gathering.id}
+                initialReviews={reviewList.data}
+                totalPages={reviewList.totalPages}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+      <BottomFloatingBarWrapper gathering={gathering} />
+      <Modal
+        size="sm"
+        isOpen={isCanceledModalOpen}
+        onClose={() => setCanceledModalOpen(false)}
+      >
+        <div className="flex w-full flex-col items-center justify-center">
+          <p className="text-secondary-900 mb-10 text-base">
+            취소된 모임입니다.
+          </p>
+          <Button size="lg" className="w-28" onClick={() => router.push("/")}>
+            확인
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+};

--- a/src/effect/gatherings/getGatheringDetail.ts
+++ b/src/effect/gatherings/getGatheringDetail.ts
@@ -11,7 +11,9 @@ export const getGatheringDetail = async (id: string) => {
 
     // 응답이 404 에러인 경우
     if (response.status === 404 || data?.code === "NOT_FOUND") {
-      return null;
+      const error = new Error("Not Found");
+      error.name = "GatheringNotFoundError";
+      throw error;
     }
 
     // 기타 서버 오류
@@ -40,4 +42,23 @@ export const getParticipants = async (id: string) => {
   }));
 
   return participantAvatars;
+};
+
+// 모임 상세 정보와 참가자 목록을 함께 가져오는 함수
+export const getGatheringInfo = async (id: string) => {
+  try {
+    // 두 API를 병렬로 호출
+    const [gathering, participants] = await Promise.all([
+      getGatheringDetail(id),
+      getParticipants(id),
+    ]);
+
+    return {
+      gathering,
+      participants,
+    };
+  } catch (error) {
+    console.error("getGatheringInfo 실패:", error);
+    throw error;
+  }
 };

--- a/src/hooks/api/useGatheringDetail.ts
+++ b/src/hooks/api/useGatheringDetail.ts
@@ -1,0 +1,21 @@
+// hooks/useGathering.ts
+import useSWR from "swr";
+import { getGatheringInfo } from "@/effect/gatherings/getGatheringDetail";
+
+export const useGatheringDetail = (id: string) => {
+  const { data, error, isLoading, mutate } = useSWR(
+    id ? `gathering-info-${id}` : null,
+    () => getGatheringInfo(id),
+    {
+      revalidateOnReconnect: true,
+    },
+  );
+
+  return {
+    gathering: data?.gathering,
+    participants: data?.participants || [],
+    isLoading,
+    isError: error,
+    mutate,
+  };
+};


### PR DESCRIPTION
## 작업 항목
- swr 설치 및 상세 정보 캐싱 관리
- 취소된 모임 접속 시, 모달 처리
- 피드백 반영
    - 참여하기, 참여 취소하기 등을 눌렀을 때 avatarList 바로 반영되지 않는 점 수정
    - toast 시간 설정

## 기타
- 리뷰도 swr로 관리할지 고려해보기
- 현재는 기존에 정의해뒀던 getGatheringDetail을 사용중인데 fetcher를 따로 사용할지 고려

route api를 사용하려고 했는데 리팩토링 과정이 복잡해지는 것 같아, 일단 기존의 fetch관련 함수를 사용하는 방안으로 1차적 리팩토링했습니다.