### PR TITLE
[refactor] 모임 찾기 리스트 초기 데이터, 필터, 정렬 등 로직 개선 (#176)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,15 @@
 
 import { getGatheringList } from "@/effect/gatherings/getGatheringList";
 import { GatheringListPage } from "@/components/molecules/gatheringListPage";
+import { mainSortOptions } from "@/constants/sortOptions";
+import { DEFAULT_TYPE } from "@/constants/category";
 
 export default async function Page() {
-  const initialData = await getGatheringList(0, 10); // offset=0, limit=10
+  // 미리 데이터 가져오기
+  const initialData = await getGatheringList(0, 10, {
+    sortBy: mainSortOptions[0].sortBy, // "registrationEnd" (마감 임박)
+    sortOrder: mainSortOptions[0].sortOrder, // "asc" (오름차순)
+    type: DEFAULT_TYPE, // "DALLAEMFIT" (기본 타입)
+  });
   return <GatheringListPage initialGatherings={initialData} />;
 }

--- a/src/components/molecules/calendar/index.tsx
+++ b/src/components/molecules/calendar/index.tsx
@@ -10,7 +10,6 @@ import { Button } from "@/components/atom/button";
 interface CalendarProps {
   mode: "date" | "datetime"; // 날짜만 선택 or 날짜+시간 선택
   selectedDate: Date | null; // 선택된 초기 날짜 값
-  onChange: (date: Date | null) => void; // 날짜가 변경될 때 호출할 함수
   onApply?: (date: Date | null) => void; // 적용 버튼 클릭 시 호출할 함수
   onReset?: () => void; // 초기화 버튼 클릭 시 호출할 함수
 }
@@ -40,7 +39,6 @@ const formattedWeekdays = Array.from({ length: DAYS_IN_WEEK }, (_, i) =>
 export const Calendar = ({
   mode,
   selectedDate,
-  onChange,
   onApply,
   onReset,
 }: CalendarProps) => {
@@ -106,7 +104,6 @@ export const Calendar = ({
     setTimePeriod("AM");
 
     // 선택된 날짜를 초기화하고, 부모 컴포넌트에 알림
-    onChange(null);
     onApply?.(null);
     onReset?.();
   };

--- a/src/components/molecules/gatheringCard/index.tsx
+++ b/src/components/molecules/gatheringCard/index.tsx
@@ -17,12 +17,14 @@ export interface GatheringCardProps {
   gathering: Gathering;
   isDimmed?: boolean;
   onClick?: () => void;
+  // index?: number;
 }
 
 export const GatheringCard = ({
   gathering,
   isDimmed = false,
   onClick,
+  // index,
 }: GatheringCardProps) => {
   const isFull = gathering.participantCount >= gathering.capacity;
 
@@ -50,6 +52,9 @@ export const GatheringCard = ({
         <DeadlineTag registrationEnd={gathering.registrationEnd} />
       </div>
 
+      {/*{gathering.id} : {gathering.registrationEnd}
+      <div>{}</div>*/}
+
       {/* 우측 본문 */}
       <div className="flex flex-1 flex-col justify-between gap-6 p-4 sm:gap-0 sm:pt-4 sm:pr-4 sm:pb-4 sm:pl-6">
         {/* 카드 헤더 그룹 */}
@@ -58,6 +63,7 @@ export const GatheringCard = ({
           <div className="flex min-w-0 flex-col gap-2">
             <header className="flex min-w-0 items-center">
               <h3 className="text-secondary-900 min-w-0 truncate text-lg font-semibold">
+                {/* [{index}] */}
                 {gathering.name}
               </h3>
               <span className="text-secondary-500 mx-2 text-sm sm:text-lg">

--- a/src/components/molecules/gatheringCardSkeleton/index.tsx
+++ b/src/components/molecules/gatheringCardSkeleton/index.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+export const SkeletonCard = () => {
+  return (
+    <div className="border-secondary-200 flex h-[332px] animate-pulse flex-col overflow-hidden rounded-3xl border-2 bg-white shadow-sm sm:h-[160px] sm:flex-row">
+      {/* 모바일: 전체를 채우는 둥근 사각형 / PC: 좌측 이미지 영역 */}
+      <div className="bg-secondary-300 h-full w-full sm:w-72" />
+
+      {/* PC에서만 보이는 텍스트 영역 */}
+      <div className="hidden flex-1 flex-col space-y-3 p-4 sm:flex sm:pt-4 sm:pr-4 sm:pb-4 sm:pl-6">
+        <div className="bg-secondary-200 h-6 w-1/2 rounded" />
+        <div className="bg-secondary-200 mt-2 h-4 w-3/4 rounded" />
+        <div className="bg-secondary-200 h-4 w-2/3 rounded" />
+        <div className="bg-secondary-200 h-4 w-5/6 rounded" />
+      </div>
+    </div>
+  );
+};

--- a/src/components/molecules/gatheringListPage/index.tsx
+++ b/src/components/molecules/gatheringListPage/index.tsx
@@ -1,223 +1,220 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useInView } from "react-intersection-observer";
 import { toast } from "react-toastify";
 
 import { getGatheringList } from "@/effect/gatherings/getGatheringList";
+import { DEFAULT_TYPE } from "@/constants/category";
+import { DEFAULT_REGION } from "@/constants/region";
+import { mainSortOptions } from "@/constants/sortOptions";
+import type { Gathering } from "@/entity/gathering";
+import { getFormattedDate } from "@/libs/date/getFormattedDate";
 import { GatheringCard } from "@/components/molecules/gatheringCard";
 import { Button } from "@/components/atom/button";
-import { Chip } from "@/components/atom/chip";
-import { Tabs, type Tab } from "@/components/atom/tabs";
+import { CategoryTab } from "@/components/molecules/categoryTab";
 import { PageHeader } from "@/components/molecules/pageHeader";
 import { FilterBar, type SortOption } from "@/components/molecules/filterBar";
 import { GatheringModal } from "@/components/organisms/gatheringModal";
-import type { Gathering } from "@/entity/gathering";
+import { SkeletonCard } from "@/components/molecules/gatheringCardSkeleton";
 
-// 상위 탭
-const topTabs: Tab[] = [
-  { label: "달램핏", value: "DALLAEMFIT", icon: "meditation" },
-  { label: "워케이션", value: "WORKATION", icon: "vacation" },
-];
-
-// 하위 탭
-const subTabs: Record<string, { label: string; value: string }[]> = {
-  DALLAEMFIT: [
-    { label: "전체", value: "DALLAEMFIT" },
-    { label: "오피스 스트레칭", value: "OFFICE_STRETCHING" },
-    { label: "마인드풀니스", value: "MINDFULNESS" },
-  ],
-  WORKATION: [], // 워케이션은 하위 카테고리 없음
-};
-
-// 정렬 옵션
-const mainSortOptions: SortOption[] = [
-  {
-    label: "마감 임박",
-    value: "closingSoon",
-    sortBy: "registrationEnd",
-    sortOrder: "asc",
-  },
-  {
-    label: "참여 인원 순",
-    value: "participants",
-    sortBy: "participantCount",
-    sortOrder: "desc",
-  },
-];
-
-// 필터 타입
 export interface Filters {
   region: string;
   date: Date | null;
   sort: SortOption;
 }
 
-interface GatheringListPageProps {
-  initialGatherings: Gathering[];
-}
-
 // 상수 정의
-const PAGE_SIZE = 10; // 한번에 가져오는 pagination 단위
+const PAGE_SIZE = 10; // 한 번에 불러올 모임 수 (무한스크롤 사용 시 기준)
+
+interface GatheringListPageProps {
+  initialGatherings: Gathering[]; // 서버에서 받아온 초기 모임 데이터
+}
 
 export function GatheringListPage({
   initialGatherings,
 }: GatheringListPageProps) {
   const router = useRouter();
-  const { ref, inView } = useInView({ threshold: 0.5 });
+  const { ref, inView } = useInView({ threshold: 1 });
+  const isInitialMount = useRef(true); // 초기 마운트 여부를 저장하는 ref
+  const [selectedType, setSelectedType] = useState(DEFAULT_TYPE);
 
-  const [selectedTopTab, setSelectedTopTab] = useState(topTabs[0]);
-  const [selectedChip, setSelectedChip] = useState<{
-    label: string;
-    value: string;
-  } | null>(null);
   const [gatherings, setGatherings] = useState(initialGatherings);
   const [skip, setSkip] = useState(PAGE_SIZE);
+  const [isLoading, setIsLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
   const [filters, setFilters] = useState<Filters>({
-    region: "all",
-    date: null,
-    sort: mainSortOptions[0],
+    region: DEFAULT_REGION, // 전체 지역이 초기값
+    date: null, // 초기엔 날짜 선택 없음
+    sort: mainSortOptions[0], // 기본 정렬 옵션 (마감 임박)
   });
+
+  // 모임 생성 모달 열림 여부 상태
   const [isGatheringModalOpen, setIsGatheringModalOpen] = useState(false);
-
-  const chips = subTabs[selectedTopTab.value];
-
+  // 모임 카드 클릭 시 해당 모임 상세 페이지로 이동
   const goToGatheringDetail = (id: number) => {
     router.push(`/gathering/${id}`);
   };
-
-  const getFormattedDate = (date: Date | null) => {
-    if (!date) return undefined;
-    const utcDate = new Date(date.getTime() - 9 * 60 * 60 * 1000);
-    return utcDate.toISOString().split("T")[0]; // 'YYYY-MM-DD'
+  // 모임 만들기 버튼 클릭 핸들러
+  const handleCreateGathering = () => {
+    const token = localStorage.getItem("token");
+    if (!token) {
+      toast.info("로그인이 필요합니다.");
+      router.push("/login");
+      return;
+    }
+    setIsGatheringModalOpen(true);
   };
 
-  // 탭 바뀔 때 자동으로 첫 칩 선택
+  // 필터나 탭 변경 시, 모임 데이터를 새로 불러오는 훅
   useEffect(() => {
-    const firstChip = subTabs[selectedTopTab.value][0] ?? null;
-    setSelectedChip(firstChip);
+    // 초기 마운트이며 기본 필터 상태일 경우, SSR 데이터를 그대로 사용하고 API 호출은 스킵
+    if (isInitialMount.current) {
+      const isDefaultState =
+        selectedType === DEFAULT_TYPE &&
+        filters.region === "all" &&
+        filters.date === null &&
+        filters.sort.value === mainSortOptions[0].value;
 
-    // filters 상태도 리셋
-    setSkip(0);
-    setHasMore(true);
-  }, [selectedTopTab]);
+      if (isDefaultState) {
+        console.log("초기 상태로 API 호출 생략");
+        isInitialMount.current = false;
+        return;
+      }
+    } else {
+      console.log("필터 변경으로 API 호출");
+      // 필터가 바뀌었거나, 최초가 아니면 API 호출
+      const formattedDate = getFormattedDate(filters.date);
+      const controller = new AbortController();
+      const signal = controller.signal;
 
+      const requestParams = {
+        region: filters.region !== "all" ? filters.region : undefined,
+        date: formattedDate, // 포맷된 날짜
+        sortBy: filters.sort.sortBy, // 정렬 기준
+        sortOrder: filters.sort.sortOrder, // 정렬 순서
+        type: selectedType, // 선택된 모임 타입
+      };
+
+      console.log("hasMore 상태:", hasMore);
+
+      setIsLoading(true);
+      setGatherings([]); // 기존 리스트 초기화
+      setSkip(PAGE_SIZE); // 다음 요청을 위해 초기화
+
+      getGatheringList(0, PAGE_SIZE, requestParams, signal)
+        .then((data) => {
+          console.log("탭변경-isLoading 상태:", isLoading);
+          if (data.length === 0) {
+            setHasMore(false);
+          } else {
+            setGatherings((prev) => [...prev, ...data]);
+          }
+          setIsLoading(false);
+        })
+        .catch((err) => {
+          if (err.name !== "AbortError") {
+            console.error("필터 변경 실패", err);
+            setIsLoading(false);
+          }
+        });
+
+      return () =>
+        controller.abort({
+          name: "AbortError",
+          message: "strict mode로 인한 API 중복 요청 방지",
+        });
+    }
+  }, [filters, selectedType]);
+
+  // 무한스크롤 동작을 위한 훅
+  // inView가 true이고, 더 불러올 게 있으며, 로딩 중이 아닐 때만 API 호출
   useEffect(() => {
     const formattedDate = getFormattedDate(filters.date);
+    const controller = new AbortController();
+    const signal = controller.signal;
 
-    getGatheringList(0, PAGE_SIZE, {
+    const infiniteScrollParams = {
       region: filters.region !== "all" ? filters.region : undefined,
       date: formattedDate,
       sortBy: filters.sort.sortBy,
       sortOrder: filters.sort.sortOrder,
-      type: selectedChip?.value ?? selectedTopTab.value,
-    }).then((newData) => {
-      setGatherings(newData);
-      setSkip(PAGE_SIZE);
-      setHasMore(true);
-    });
-  }, [filters, selectedTopTab, selectedChip?.value]);
+      type: selectedType,
+    };
 
-  useEffect(() => {
-    if (inView && hasMore) {
-      const formattedDate = getFormattedDate(filters.date);
-      getGatheringList(skip, PAGE_SIZE, {
-        region: filters.region !== "all" ? filters.region : undefined,
-        date: formattedDate,
-        sortBy: filters.sort.sortBy,
-        sortOrder: filters.sort.sortOrder,
-        type: selectedChip ? selectedChip.value : selectedTopTab.value,
-      }).then((newData) => {
+    // inView가 true이고, 더 불러올 게 있으며, 로딩 중이 아닐 때만 API 호출
+    getGatheringList(skip, PAGE_SIZE, infiniteScrollParams, signal)
+      .then((newData) => {
+        setIsLoading(true);
+        console.log("무한- isLoading 상태:", isLoading);
         if (newData.length === 0) {
           setHasMore(false);
         } else {
           setGatherings((prev) => [...prev, ...newData]);
-          setSkip((prev) => prev + PAGE_SIZE);
+        }
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        // AbortError는 무시, 다른 에러만 처리
+        if (error.name !== "AbortError") {
+          console.error("API 요청 실패:", error);
+          setIsLoading(false);
         }
       });
+    return () =>
+      controller.abort({
+        name: "AbortError",
+        message: "strict mode로 인한 API 중복 요청 방지",
+      });
+  }, [skip, filters, selectedType]);
+
+  useEffect(() => {
+    // inView가 true이고, 더 불러올 게 있으며, 로딩 중이 아닐 때만 skip 증가
+    if (inView && hasMore && !isLoading) {
+      setSkip((prev) => {
+        return prev + PAGE_SIZE; // 다음 페이지를 불러오기 위해 skip 증가
+      });
     }
-  }, [inView, skip, filters, hasMore, selectedTopTab, selectedChip]);
+  }, [inView, hasMore]);
 
   return (
     <main className="flex flex-col bg-gray-100">
       <h2 className="sr-only">모임 찾기</h2>
 
       <section
-        style={{ minHeight: "calc(100vh - 60px)" }}
         className="bg-secondary-50 mx-auto w-full max-w-[1200px] px-4 py-6 sm:px-6 sm:py-10 lg:px-[100px]"
+        style={{ minHeight: "calc(100vh - 60px)" }}
       >
+        {/* 페이지 헤더 */}
         <PageHeader />
 
-        <div className="flex items-center justify-between">
-          <Tabs
-            tabs={topTabs}
-            selectedTab={selectedTopTab}
-            onChange={(tab) => {
-              setSelectedChip(null); // 먼저 칩 초기화
-              setSelectedTopTab(tab); // 그 다음 탭 바꿈
-            }}
-          />
+        {/* 상단 탭 영역 */}
+        <div className="flex items-start justify-between">
+          {/* 카테고리 탭 */}
+          <CategoryTab setSelectedType={setSelectedType} />
+
+          {/* 모임 만들기 버튼 */}
           <Button
-            onClick={() => {
-              const token = localStorage.getItem("token");
-
-              if (!token) {
-                toast.info("로그인이 필요합니다.");
-                router.push("/login");
-                return;
-              }
-
-              setIsGatheringModalOpen(true);
-            }}
+            onClick={handleCreateGathering}
             className="h-11 w-[115px] cursor-pointer"
           >
             모임 만들기
           </Button>
         </div>
 
-        {/* 칩 렌더링 */}
-        {chips.length > 0 && (
-          <div className="mt-2.5 flex flex-wrap gap-2 sm:mt-3.5">
-            {chips.map(({ label, value }) => (
-              <Chip
-                key={value}
-                label={label}
-                selected={selectedChip?.value === value}
-                onClick={() => {
-                  setSelectedChip({ label, value });
-
-                  const formattedDate = getFormattedDate(filters.date);
-
-                  getGatheringList(0, PAGE_SIZE, {
-                    region:
-                      filters.region !== "all" ? filters.region : undefined,
-                    date: formattedDate,
-                    sortBy: filters.sort.sortBy,
-                    sortOrder: filters.sort.sortOrder,
-                    type: value, // 클릭한 칩의 value로 API 호출
-                  }).then((newData) => {
-                    setGatherings(newData); // 새 데이터로 덮어쓰기
-                    setSkip(PAGE_SIZE); // skip 초기화
-                    setHasMore(true); // 무한스크롤 다시 가능
-                  });
-                }}
-              />
-            ))}
-          </div>
-        )}
-
+        {/* 지역, 날짜, 정렬 필터를 한 줄로 보여주는 필터바 */}
         <div className="mt-4 border-t-2 border-gray-200 pt-3 sm:pt-4">
           <FilterBar
-            sortOptions={mainSortOptions}
-            defaultSortValue="closingSoon"
+            sortOptions={mainSortOptions} // 정렬 옵션 목록
+            defaultSortValue="closingSoon" // 기본 정렬값
             onFilterChange={({ region, date, sort }) => {
-              setFilters({ region, date, sort });
+              setFilters({ region, date, sort }); // 필터 상태 업데이트
             }}
           />
         </div>
 
+        {/* 모임 카드 리스트 */}
         <div className="mt-6 flex flex-col gap-4">
           {gatherings.length === 0 ? (
             <div className="flex min-h-[300px] flex-col items-center justify-center text-center text-gray-500">
@@ -228,23 +225,36 @@ export function GatheringListPage({
               </p>
             </div>
           ) : (
-            gatherings.map((gathering, index) => (
-              <GatheringCard
-                key={`${gathering.id}-${index}`}
-                gathering={gathering}
-                isDimmed={false}
-                onClick={() => goToGatheringDetail(gathering.id)}
-              />
-            ))
+            <>
+              {gatherings.map((gathering, index) => (
+                <GatheringCard
+                  key={`${gathering.id}-${index}`}
+                  gathering={gathering}
+                  isDimmed={false}
+                  // index={index}
+                  onClick={() => goToGatheringDetail(gathering.id)}
+                />
+              ))}
+            </>
+          )}
+          {/* 로딩 중일 때 스켈레톤 UI 표시 */}
+          {isLoading && (
+            <div className="flex flex-col gap-4">
+              {[...Array(6)].map((_, idx) => (
+                <SkeletonCard key={idx} />
+              ))}
+            </div>
           )}
         </div>
 
+        {/* 리스트가 10개 이상이고, 더 불러올 게 있을 때만 옵저버 동작 */}
         <div ref={ref} className="h-10 w-full overflow-hidden opacity-0" />
       </section>
 
+      {/* 모임 만들기 모달: isOpen 상태에 따라 노출 */}
       <GatheringModal
-        isOpen={isGatheringModalOpen}
-        onClose={() => setIsGatheringModalOpen(false)}
+        isOpen={isGatheringModalOpen} // 열림 여부
+        onClose={() => setIsGatheringModalOpen(false)} // 닫기 핸들러
       />
     </main>
   );

--- a/src/components/molecules/gatheringListPage/index.tsx
+++ b/src/components/molecules/gatheringListPage/index.tsx
@@ -167,7 +167,7 @@ export function GatheringListPage({
         name: "AbortError",
         message: "strict mode로 인한 API 중복 요청 방지",
       });
-  }, [skip, filters, selectedType]);
+  }, [skip, filters, selectedType, isLoading]);
 
   useEffect(() => {
     // inView가 true이고, 더 불러올 게 있으며, 로딩 중이 아닐 때만 skip 증가
@@ -176,7 +176,7 @@ export function GatheringListPage({
         return prev + PAGE_SIZE; // 다음 페이지를 불러오기 위해 skip 증가
       });
     }
-  }, [inView, hasMore]);
+  }, [inView, hasMore, isLoading]);
 
   return (
     <main className="flex flex-col bg-gray-100">

--- a/src/constants/region.ts
+++ b/src/constants/region.ts
@@ -1,0 +1,9 @@
+export const REGION_OPTIONS = [
+  { label: "지역 전체", value: "all" },
+  { label: "건대입구", value: "건대입구" },
+  { label: "을지로3가", value: "을지로3가" },
+  { label: "신림", value: "신림" },
+  { label: "홍대입구", value: "홍대입구" },
+];
+
+export const DEFAULT_REGION = "all";

--- a/src/constants/sortOptions.ts
+++ b/src/constants/sortOptions.ts
@@ -1,20 +1,20 @@
 import { SortOption } from "@/entity/filters";
 
 // 메인페이지 정렬 옵션
-// const mainSortOptions: SortOption[] = [
-//   {
-//     label: "마감 임박",
-//     value: "closingSoon",
-//     sortBy: "registrationEnd",
-//     sortOrder: "asc",
-//   },
-//   {
-//     label: "참여 인원 순",
-//     value: "participants",
-//     sortBy: "participantCount",
-//     sortOrder: "desc",
-//   },
-// ];
+export const mainSortOptions: SortOption[] = [
+  {
+    label: "마감 임박",
+    value: "closingSoon",
+    sortBy: "registrationEnd",
+    sortOrder: "asc",
+  },
+  {
+    label: "참여 인원 순",
+    value: "participants",
+    sortBy: "participantCount",
+    sortOrder: "desc",
+  },
+];
 
 // 리뷰페이지 정렬 옵션
 export const reviewsSortOptions: SortOption[] = [

--- a/src/effect/gatherings/getGatheringList.ts
+++ b/src/effect/gatherings/getGatheringList.ts
@@ -17,6 +17,7 @@ export const getGatheringList = async (
     sortOrder?: "asc" | "desc"; // 정렬 순서
     type?: string; // 모임 타입(상위/하위 카테고리)
   },
+  signal?: AbortSignal | null,
 ) => {
   const params = new URLSearchParams();
   params.append("offset", offset.toString());
@@ -47,6 +48,7 @@ export const getGatheringList = async (
     `${BASE_URL}/${TEAM_ID}/gatherings?${params.toString()}`,
     {
       cache: "no-store", // 캐시를 사용하지 않고 항상 최신 데이터를 가져옴
+      signal,
     },
   );
 
@@ -57,8 +59,11 @@ export const getGatheringList = async (
   // 받아온 데이터
   const data: Gathering[] = await response.json();
   const now = new Date(); // 현재 시각
+
   // 취소되지 않았고, 현재 시각 이후에 열리는 모임만 필터링
-  return data.filter(
+  const valid = data.filter(
     (item) => item.canceledAt === null && new Date(item.dateTime) > now,
   );
+
+  return valid;
 };


### PR DESCRIPTION
## 설명
메인페이지 SSR 초기 로딩, 필터링/정렬 기능 개선을 위해 코드 리팩토링 및 신규 파일을 추가했습니다.  

## 작업 내용
- SSR로 초기 모임 리스트 불러올 때, 정렬 기준과 기본 카테고리 반영되도록 수정
- 정렬 옵션(mainSortOptions) 추가
- 지역 필터 옵션 상수로 분리 (`REGION_OPTIONS`, `DEFAULT_REGION`)
- 스켈레톤 카드 UI 추가 (로딩 중일 때 보여주는 화면)
- API 호출 함수에서 날짜, 지역, 정렬 기준, 카테고리 등을 필터로 전달 가능하게 개선
- fetch 요청 중 화면이 바뀔 때 이전 요청을 중단할 수 있도록 처리
- `categoryTab`등 컴포넌트화된 요소들 적용

 ## 미해결 (작업 예정)
- 날짜 필터링이 제대로 작동하지 않는 오류 해결
- 탭 전환 시 데이터가 겹쳐서 랜더링되는 문제 해결