### PR TITLE
fix: minor-fixes (#184)

### DIFF
--- a/src/components/molecules/gatheringCard/index.tsx
+++ b/src/components/molecules/gatheringCard/index.tsx
@@ -41,7 +41,7 @@ export const GatheringCard = ({
       )}
     >
       {/* 썸네일 이미지 */}
-      <div className="relative h-[156px] w-full sm:w-72">
+      <div className="relative h-[156px] w-full sm:w-72 sm:flex-shrink-0">
         <Image
           src={gathering.image || "/image/alt-place.jpg"}
           alt={gathering.name}
@@ -57,7 +57,7 @@ export const GatheringCard = ({
       <div>{}</div>*/}
 
       {/* 우측 본문 */}
-      <div className="flex flex-1 flex-col justify-between gap-6 p-4 sm:gap-0 sm:pt-4 sm:pr-4 sm:pb-4 sm:pl-6">
+      <div className="flex flex-1 flex-col justify-between gap-6 overflow-hidden p-4 sm:gap-0 sm:pt-4 sm:pr-4 sm:pb-4 sm:pl-6">
         {/* 카드 헤더 그룹 */}
         <div className="flex items-start justify-between gap-2">
           {/* 텍스트 정보 영역 */}
@@ -67,7 +67,7 @@ export const GatheringCard = ({
                 {/* [{index}] */}
                 {gathering.name}
               </h3>
-              <span className="text-secondary-500 mx-2 text-sm sm:text-lg">
+              <span className="text-secondary-500 mx-2 flex-shrink-0 text-sm sm:text-lg">
                 |
               </span>
               <p className="text-secondary-700 min-w-0 truncate">

--- a/src/components/molecules/gatheringInformation/index.tsx
+++ b/src/components/molecules/gatheringInformation/index.tsx
@@ -23,8 +23,10 @@ export const GatheringInformation = ({
       </div>
 
       {/* 상세 정보 */}
-      <div className="relative flex w-fit grow flex-col">
-        <p className="text-lg font-semibold">{gatheringInfo?.name}</p>
+      <div className="relative flex w-full grow flex-col">
+        <p className="truncate pr-14 text-lg font-semibold">
+          {gatheringInfo?.name}
+        </p>
 
         <div className="mt-1 flex gap-x-2">
           {/* 날짜 및 시간 */}

--- a/src/components/molecules/gatheringInformation/participantInfo.tsx
+++ b/src/components/molecules/gatheringInformation/participantInfo.tsx
@@ -25,7 +25,7 @@ export const ParticipantInfo = ({
   useEffect(() => {
     const control = animate(motionValue, participantCount, { duration: 1.5 });
     return () => control.stop();
-  }, []);
+  }, [participantCount]);
 
   return (
     <div className="flex w-full flex-col gap-y-2.5">

--- a/src/components/molecules/pageHeader/index.tsx
+++ b/src/components/molecules/pageHeader/index.tsx
@@ -1,7 +1,7 @@
 import { LikedHeaderIcon } from "@/components/icons/LikedHeaderIcon";
 import { PageHeaderIcon } from "@/components/icons/PageHeaderIcon";
 import { ReviewHeaderIcon } from "@/components/icons/ReviewHeaderIcon";
-
+import clsx from "clsx";
 interface PageHeaderProps {
   page: "main" | "liked" | "reviews";
 }
@@ -27,7 +27,7 @@ export const PageHeader = ({ page }: PageHeaderProps) => {
 
   const headerTitleStyle =
     "text-secondary-900 text-lg leading-none font-semibold sm:text-2xl";
-  const headerTextStyle = "text-secondary-700 mt-2";
+  const headerTextStyle = "text-secondary-700";
   return (
     <div className="mb-8 flex items-center gap-6">
       {/* 아이콘 - 원형 배경 포함 */}
@@ -40,12 +40,14 @@ export const PageHeader = ({ page }: PageHeaderProps) => {
         {page === "main" ? (
           <>
             <p className={headerTextStyle}>{headerText[page]}</p>
-            <h3 className={headerTitleStyle}>{headerTitle[page]}</h3>
+            <h3 className={clsx(headerTitleStyle, "mt-2")}>
+              {headerTitle[page]}
+            </h3>
           </>
         ) : (
           <>
             <h3 className={headerTitleStyle}>{headerTitle[page]}</h3>
-            <p className={headerTextStyle}>{headerText[page]}</p>
+            <p className={clsx(headerTextStyle, "mt-2")}>{headerText[page]}</p>
           </>
         )}
       </div>

--- a/src/constants/sortOptions.ts
+++ b/src/constants/sortOptions.ts
@@ -22,7 +22,7 @@ export const reviewsSortOptions: SortOption[] = [
     label: "최신 순",
     value: "createdAt",
     sortBy: "createdAt",
-    sortOrder: "asc",
+    sortOrder: "desc",
   },
   {
     label: "리뷰 높은 순",

--- a/src/hooks/api/useLikedGatherings.ts
+++ b/src/hooks/api/useLikedGatherings.ts
@@ -4,7 +4,7 @@ import useLikeStore from "@/stores/useLikeStore";
 import { useEffect, useState, useCallback } from "react";
 
 export const useLikedGatherings = () => {
-  const { likedGatheringIds } = useLikeStore();
+  const { likedGatheringIds, toggleLike } = useLikeStore();
   const [gatherings, setGatherings] = useState<Gathering[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -35,13 +35,18 @@ export const useLikedGatherings = () => {
 
       setGatherings(validGatherings);
 
-      // 실패한 요청이 있으면 에러 상태 설정
-      const failedCount = results.filter(
-        (result) => result.status === "rejected",
-      ).length;
+      // 실패한 요청들의 ID 추출 및 로컬스토리지에서 제거
+      const failedIds: number[] = [];
+      results.forEach((result, index) => {
+        if (result.status === "rejected") {
+          const failedId = likedGatheringIds[index];
+          failedIds.push(failedId);
+          toggleLike(failedId); // 실패한 ID를 로컬스토리지에서 제거
+        }
+      });
 
-      if (failedCount > 0) {
-        setError(`${failedCount}개 모임 정보를 불러오지 못했습니다.`);
+      if (failedIds.length > 0) {
+        setError(`${failedIds.length}개 모임 정보를 불러오지 못했습니다.`);
       }
     } catch (error) {
       setError("찜한 모임을 불러오는 중 오류가 발생했습니다.");


### PR DESCRIPTION
## 작업 내용
- 상세페이지에서 "참여하기" 버튼을 누르면 참여 인원이 바뀌지 않음 
> useEffect 의존성 배열 수정
- 리뷰페이지 "최신순" 오류 : 정렬 옵션 수정
- gatheringCard 이미지 크기 달라짐
> - 원인 : `모임명` 등의 텍스트가 길어지면서 이미지의 영역이 줄어듬
> - 해결 : 이미지의 영역이 줄어들지 않게 수정하고, 텍스트 truncate 처리
> - 상세페이지에도 동일하게 적용
예시) 
- 기존
![Image](https://github.com/user-attachments/assets/ffae5b30-c342-4478-b0a2-739e9c27539c)
- 수정 후
![image](https://github.com/user-attachments/assets/aeeca840-00e9-4be1-9c55-aa1035c4fe1f)

### 기타
- 로컬스토리지에 찜한 모임 목록에 유효하지 않은 gatheringId 가 있을 시, 해당 id를 제거하는 로직 추가

Closes #184