### PR TITLE
[refactor] Filters 타입 정리 및 import 개선 (#193)

### DIFF
--- a/src/components/molecules/filterBar/index.tsx
+++ b/src/components/molecules/filterBar/index.tsx
@@ -1,17 +1,10 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import dayjs from "dayjs";
 
+import { REGION_OPTIONS, DEFAULT_REGION } from "@/constants/region";
 import { Dropdown } from "@/components/atom/dropdown";
 import { Calendar } from "@/components/molecules/calendar";
-import type { Filters } from "@/components/molecules/gatheringListPage";
-import { REGION_OPTIONS, DEFAULT_REGION } from "@/constants/region";
-
-export interface SortOption {
-  label: string;
-  value: string;
-  sortBy: string;
-  sortOrder: "asc" | "desc";
-}
+import type { SortOption, Filters } from "@/entity/filters";
 
 interface FilterBarProps {
   sortOptions: SortOption[]; // 정렬 옵션 배열

--- a/src/components/molecules/gatheringListPage/index.tsx
+++ b/src/components/molecules/gatheringListPage/index.tsx
@@ -7,24 +7,21 @@ import { toast } from "react-toastify";
 
 import { getGatheringList } from "@/effect/gatherings/getGatheringList";
 import { DEFAULT_TYPE } from "@/constants/category";
-import { DEFAULT_REGION } from "@/constants/region";
+import { DEFAULT_FILTERS } from "@/constants/filters";
 import { mainSortOptions } from "@/constants/sortOptions";
-import type { Gathering } from "@/entity/gathering";
+
 import { getFormattedDate } from "@/libs/date/getFormattedDate";
 import { GatheringCard } from "@/components/molecules/gatheringCard";
 import { Button } from "@/components/atom/button";
 import { CategoryTab } from "@/components/molecules/categoryTab";
 import { PageHeader } from "@/components/molecules/pageHeader";
-import { FilterBar, type SortOption } from "@/components/molecules/filterBar";
+import { FilterBar } from "@/components/molecules/filterBar";
 import { SkeletonCard } from "@/components/molecules/gatheringCardSkeleton";
 import { Modal } from "@/components/atom/modal";
 import { CreateGatheringModalUI } from "@/components/organisms/createGatheringModalUI";
 
-export interface Filters {
-  region: string;
-  date: Date | null;
-  sort: SortOption;
-}
+import type { Gathering } from "@/entity/gathering";
+import type { Filters } from "@/entity/filters";
 
 // 상수 정의
 const PAGE_SIZE = 10; // 한 번에 불러올 모임 수 (무한스크롤 사용 시 기준)
@@ -45,11 +42,7 @@ export function GatheringListPage({
   const [skip, setSkip] = useState(PAGE_SIZE);
   const [isLoading, setIsLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
-  const [filters, setFilters] = useState<Filters>({
-    region: DEFAULT_REGION, // 전체 지역이 초기값
-    date: null, // 초기엔 날짜 선택 없음
-    sort: mainSortOptions[0], // 기본 정렬 옵션 (마감 임박)
-  });
+  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
 
   // 모임 생성 모달 열림 여부 상태
   const [isGatheringModalOpen, setIsGatheringModalOpen] = useState(false);

--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -1,0 +1,10 @@
+import { DEFAULT_REGION } from "./region";
+import { mainSortOptions } from "./sortOptions";
+import { type Filters } from "@/entity/filters";
+
+// Filters 초기 상태
+export const DEFAULT_FILTERS: Filters = {
+  region: DEFAULT_REGION,
+  date: null,
+  sort: mainSortOptions[0], // 마감 임박 기준
+};


### PR DESCRIPTION
## 설명
유지보수 용이성 향상을 위해 필터 관련 타입(SortOption, Filters)을 `src/entity/filters.ts`로 통합하고, 중복 정의 제거 및 import 정리합니다.

## 작업 항목
- 타입 중복 제거
- import 정리
- 관련 컴포넌트 적용