### PR TITLE
feat(entities): user entity 구조 생성 - Issue #5

### DIFF
--- a/__tests__/fixtures/user-fixture.ts
+++ b/__tests__/fixtures/user-fixture.ts
@@ -1,4 +1,4 @@
-import { User } from "@/entity/user";
+import { User } from "@/entities/user";
 
 export const TEAM_ID_MAP: Record<string, number> = {
   slotest: 0,

--- a/__tests__/generator/index.ts
+++ b/__tests__/generator/index.ts
@@ -1,4 +1,4 @@
-import { User } from "@/entity/user";
+import { User } from "@/entities/user";
 import { ReviewDetail } from "@/entity/review";
 import { faker } from "@faker-js/faker";
 

--- a/src/components/molecules/bottomFloatingBar/bottomFloatingBarWrapper.tsx
+++ b/src/components/molecules/bottomFloatingBar/bottomFloatingBarWrapper.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { cancelGathering } from "@/effect/gatherings/cancelGathering";
 import { joinGathering } from "@/effect/gatherings/joinGathering";
 import { leaveGathering } from "@/effect/gatherings/leaveGathering";
-import useUserStore from "@/stores/userStore";
+import { useUserStore } from "@/entities/user";
 import { getJoinedGatherings } from "@/effect/gatherings/getJoinedGatherings";
 import axios from "axios";
 import { toast } from "react-toastify";

--- a/src/components/molecules/gnb/index.tsx
+++ b/src/components/molecules/gnb/index.tsx
@@ -5,7 +5,7 @@ import { Badge, Avatar } from "@/shared/ui";
 import { NavItem } from "@/components/atom/navItem";
 import { Logo } from "@/components/atom/logo";
 import { Dropdown } from "@/components/atom/dropdown";
-import useUserStore from "@/stores/userStore";
+import { useUserStore } from "@/entities/user";
 import { usePathname, useRouter } from "next/navigation";
 import useLikeStore from "@/stores/useLikeStore";
 

--- a/src/components/molecules/myReviews/index.tsx
+++ b/src/components/molecules/myReviews/index.tsx
@@ -7,7 +7,7 @@ import { HorizontalWritableReviewCard } from "../horizontalWritableReviewCard";
 import { ReviewModal } from "../reviewModal";
 import { useCompletedGatherings } from "@/hooks/api/useCompletedGatherings";
 import { useUserReviews } from "@/hooks/api/useUserReviews";
-import useUserStore from "@/stores/userStore";
+import { useUserStore } from "@/entities/user";
 import { toast } from "react-toastify";
 import { mutate } from "swr";
 import { JoinedGathering } from "@/entity/gathering";

--- a/src/components/molecules/profileEditModal/index.tsx
+++ b/src/components/molecules/profileEditModal/index.tsx
@@ -1,12 +1,10 @@
 import { Button, Modal, Input } from "@/shared/ui";
-import { User } from "@/entity/user";
 import Image from "next/image";
 import { useState } from "react";
-import useUserStore from "@/stores/userStore";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 import axios from "axios";
-import { updateUser } from "@/effect/user";
+import { User, useUserStore, updateUser } from "@/entities/user";
 
 interface ProfileEditModalProps {
   isOpen: boolean;

--- a/src/components/molecules/profileSection/index.tsx
+++ b/src/components/molecules/profileSection/index.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import type { User } from "@/entity/user";
+import type { User } from "@/entities/user";
 import { Avatar } from "@/shared/ui";
 import { ProfileEditModal } from "../profileEditModal";
 

--- a/src/components/molecules/tabContent/index.tsx
+++ b/src/components/molecules/tabContent/index.tsx
@@ -6,7 +6,7 @@ import { MyReviews } from "../myReviews";
 import { CreatedGatherings } from "../createdGatherings";
 import { useMyGatherings } from "@/hooks/api/useMyGatherings";
 import { useCreatedGatherings } from "@/hooks/api/useCreatedGatherings";
-import useUserStore from "@/stores/userStore";
+import { useUserStore } from "@/entities/user";
 
 interface TabContentProps {
   activeTab: Tab;

--- a/src/components/organisms/loginForm/index.tsx
+++ b/src/components/organisms/loginForm/index.tsx
@@ -2,8 +2,7 @@
 
 import { Button, Input } from "@/shared/ui";
 import { signIn } from "@/effect/auth";
-import { LoginFormInput } from "@/entity/user";
-import useUserStore from "@/stores/userStore";
+import { LoginFormInput, useUserStore } from "@/entities/user";
 import axios from "axios";
 import Link from "next/link";
 import { useRouter } from "next/navigation";

--- a/src/components/organisms/myContentPage/index.tsx
+++ b/src/components/organisms/myContentPage/index.tsx
@@ -7,8 +7,7 @@ import { toast } from "react-toastify";
 import { ProfileSection } from "@/components/molecules/profileSection";
 import { Tab, Tabs } from "@/shared/ui";
 import { TabContent } from "@/components/molecules/tabContent";
-import useUserStore from "@/stores/userStore";
-import { fetchUser } from "@/effect/user";
+import { useUserStore, fetchUser } from "@/entities/user";
 
 const tabs = [
   { label: "나의 모임", value: "gatherings" },

--- a/src/components/organisms/signUpForm/index.tsx
+++ b/src/components/organisms/signUpForm/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { Button, Input } from "@/shared/ui";
-import { signUp } from "@/effect/user";
-import { SignUpFormInput } from "@/entity/user";
+import { signUp, SignUpFormInput } from "@/entities/user";
 import axios from "axios";
 import Link from "next/link";
 import { useRouter } from "next/navigation";

--- a/src/effect/auth/index.ts
+++ b/src/effect/auth/index.ts
@@ -1,6 +1,5 @@
-import { LoginFormInput } from "@/entity/user";
+import { LoginFormInput, fetchUser } from "@/entities/user";
 import { client } from "@/shared/api";
-import { fetchUser } from "../user";
 
 export const signIn = async (data: LoginFormInput) => {
   const response = await client.post(`/auths/signin`, data);

--- a/src/entities/user/api/index.ts
+++ b/src/entities/user/api/index.ts
@@ -1,0 +1,1 @@
+export { signUp, fetchUser, updateUser } from "./userApi";

--- a/src/entities/user/api/userApi.ts
+++ b/src/entities/user/api/userApi.ts
@@ -1,0 +1,41 @@
+import { client } from "@/shared/api";
+import { SignUpFormInput } from "../model/types";
+
+export const signUp = async (data: SignUpFormInput) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { passwordCheck, ...signUpData } = data;
+  const response = await client.post(`/auths/signup`, signUpData);
+  return response.data;
+};
+
+export const fetchUser = async () => {
+  const response = await client.get(`/auths/user`);
+  const data = await response.data;
+
+  return data;
+};
+
+export const updateUser = async (user: {
+  image: FileList | null;
+  companyName: string;
+}) => {
+  try {
+    const formData = new FormData();
+
+    if (user.image && user.image.length > 0) {
+      formData.append("image", user.image[0]);
+    }
+
+    formData.append("companyName", user.companyName);
+
+    const response = await client.put(`/auths/user`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("유저 수정 중 오류:", error);
+    throw error;
+  }
+};

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,0 +1,3 @@
+export type { User, SignUpFormInput, LoginFormInput } from "./model";
+export { useUserStore } from "./model";
+export { signUp, fetchUser, updateUser } from "./api";

--- a/src/entities/user/model/index.ts
+++ b/src/entities/user/model/index.ts
@@ -1,0 +1,2 @@
+export type { User, SignUpFormInput, LoginFormInput } from "./types";
+export { default as useUserStore } from "./store";

--- a/src/entities/user/model/store.ts
+++ b/src/entities/user/model/store.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { User } from "./types";
+
+interface UserStore {
+  user: User | null;
+  setUser: (user: User | null) => void;
+}
+
+const useUserStore = create<UserStore>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user: User | null) => set({ user }),
+    }),
+    {
+      name: "user",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
+
+export default useUserStore;

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -1,0 +1,20 @@
+export interface User {
+  teamId: number;
+  id: number;
+  email: string;
+  name: string;
+  companyName: string;
+  image: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SignUpFormInput
+  extends Pick<User, "name" | "email" | "companyName"> {
+  password: string;
+  passwordCheck: string;
+}
+
+export interface LoginFormInput extends Pick<User, "email"> {
+  password: string;
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,4 +1,4 @@
-import { LoginFormInput, User } from "@/entity/user";
+import { LoginFormInput, User } from "@/entities/user";
 
 export interface AuthContextType {
   user: User | null;


### PR DESCRIPTION
## FSD 마이그레이션: user entity 구조 생성

### 🎯 목표
Issue #5: User 도메인의 entity 레이어를 FSD 구조로 마이그레이션

### 📋 변경사항
- [x] `src/entities/user` 디렉토리 구조 생성
- [x] User 타입들을 `entities/user/model/types.ts`로 이동
- [x] useUserStore를 `entities/user/model/store.ts`로 이동  
- [x] User API 함수들을 `entities/user/api/userApi.ts`로 이동
- [x] 적절한 배럴 익스포트 추가
- [x] 앱 전체의 import 경로 업데이트 (13개 파일)

### 🏗️ 새로운 구조
src/entities/user/
├── model/
│ ├── types.ts # User, SignUpFormInput, LoginFormInput
│ ├── store.ts # useUserStore (Zustand)
│ └── index.ts # model exports
├── api/
│ ├── userApi.ts # signUp, fetchUser, updateUser
│ └── index.ts # api exports
└── index.ts # main exports

### ✅ 테스트
- [x] TypeScript 컴파일 성공
- [x] Next.js 프로덕션 빌드 성공
- [x] 모든 기능 정상 동작 확인
- [x] Commitlint & Lint-staged 통과

### 🔄 마이그레이션된 파일들
**기존 → 신규**
- `src/entity/user.ts` → `src/entities/user/model/types.ts`
- `src/stores/userStore/` → `src/entities/user/model/store.ts`
- `src/effect/user/` → `src/entities/user/api/userApi.ts`

**업데이트된 파일들 (13개)**
- 모든 user 관련 import를 `@/entities/user`로 통일

### 🎯 다음 단계
- Issue #6: gathering entity 구조 생성
- Issue #7: review entity 구조 생성

### 📝 FSD 준수사항
- [x] FSD 레이어 규칙 준수 
- [x] 순환 의존성 없음
- [x] 적절한 import 방향 (shared ← entities)

**Closes #211**